### PR TITLE
Fix CI: clootl + rtrees via Remotes field; rtrees multiPhylo handling; print-method robustness

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # The DESCRIPTION's `Remotes:` field points pak at
+          # `eliotmiller/clootl` and `daijiang/rtrees` (GitHub-only
+          # backends for `pr_get_tree()`), so they install correctly
+          # during dependency resolution.
           extra-packages: any::rcmdcheck
           needs: check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,6 +63,9 @@ Suggests:
 Additional_repositories:
     https://eliotmiller.r-universe.dev,
     https://daijiang.r-universe.dev
+Remotes:
+    github::eliotmiller/clootl,
+    github::daijiang/rtrees
 LazyData: true
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/pr_get_tree.R
+++ b/R/pr_get_tree.R
@@ -296,16 +296,30 @@ pr_get_tree <- function(x,
     ...
   )
 
+  # rtrees returns a phylo when only one source tree was used, and a
+  # multiPhylo when many were sampled (e.g. 100 trees from the bird /
+  # mammal posterior). Pull the tip-label set from whichever shape we
+  # got -- for a multiPhylo all trees share the same tip set so the
+  # first one is enough.
+  ref_tips <- if (inherits(tree, "multiPhylo")) {
+    tree[[1]]$tip.label
+  } else {
+    tree$tip.label
+  }
+
   # Determine matched / unmatched. rtrees may graft species at higher
   # taxonomic nodes (genus/family); we report both placement types.
+  # Strip the trailing `*` rtrees adds to grafted tips before
+  # normalising.
+  ref_tips_clean <- sub("\\*$", "", ref_tips)
   norm_req <- pr_normalize_names(species)
-  norm_tip <- pr_normalize_names(tree$tip.label)
+  norm_tip <- pr_normalize_names(ref_tips_clean)
   in_tree  <- norm_req %in% norm_tip
 
   # If show_grafted = TRUE rtrees flags grafted tips with a `*`. Surface
   # the grafted set so users can see which species were placed on
   # higher-rank stand-ins rather than at their actual position.
-  grafted <- grep("\\*$", tree$tip.label, value = TRUE)
+  grafted <- grep("\\*$", ref_tips, value = TRUE)
 
   list(
     tree         = tree,
@@ -327,13 +341,30 @@ pr_get_tree <- function(x,
 #' @export
 print.pr_tree_result <- function(x, ...) {
   cli::cli_h1("Tree retrieval result")
+
+  # Some backends (rtrees, clootl) can return a multiPhylo when more
+  # than one source tree was used. Print a one-tree summary if it's a
+  # single phylo, else summarise the list.
+  is_multi <- inherits(x$tree, "multiPhylo")
+  n_tips_str <- if (is_multi) {
+    sprintf("%d tree%s", length(x$tree),
+            if (length(x$tree) == 1) "" else "s")
+  } else {
+    n_tips <- ape::Ntip(x$tree)
+    sprintf("%d tip%s",
+            n_tips, if (n_tips == 1) "" else "s")
+  }
+  n_matched <- length(x$matched)
+  n_unmatched <- length(x$unmatched)
+
   cli::cli_bullets(c(
-    "*" = "Source:        {.val {x$source}}",
-    "*" = "Tree:          {.val {ape::Ntip(x$tree)}} tip{?s}, {.val {x$tree$Nnode}} internal node{?s}",
-    "*" = "Matched:       {length(x$matched)} species",
-    "!" = "Unmatched:     {length(x$unmatched)} species"
+    "*" = "Source:    {.val {x$source}}",
+    "*" = "Tree:      {n_tips_str}",
+    "*" = "Matched:   {.val {n_matched}} species",
+    "!" = "Unmatched: {.val {n_unmatched}} species"
   ))
-  if (length(x$unmatched) > 0) {
+
+  if (n_unmatched > 0) {
     show <- utils::head(x$unmatched, 5)
     cli::cli_alert_info(
       "First {length(show)} unmatched: {.val {show}}"


### PR DESCRIPTION
PR #43's R-CMD-check failed on CI because pak couldn't resolve `clootl` and `rtrees` -- they're listed in `Suggests` but live on GitHub, not CRAN, and `Additional_repositories:` alone wasn't enough.

## Root cause

```
✖ Could not solve package dependencies:
* deps::.: Can't install dependency rtrees
* rtrees: Can't find package called rtrees.
```

pak's `lockfile_create()` doesn't read `Additional_repositories:` from DESCRIPTION; it reads `Remotes:`.

## Fix

* **DESCRIPTION gains a `Remotes:` field** pointing pak at `github::eliotmiller/clootl` and `github::daijiang/rtrees`. pak honours this during dependency resolution.
* `Additional_repositories:` kept for users who install via `install.packages()` (R's resolver) rather than pak.
* No workflow changes needed -- `Remotes:` does it.

## Live-testing-driven fixes

Running `pr_get_tree()` end-to-end with real backends surfaced two bugs in the rtrees branch I shipped in #43:

1. **rtrees returns a `multiPhylo`** (not a single `phylo`) for bird, mammal, etc. -- 100 trees from a posterior. My match logic was looking at `tree$tip.label` which is `NULL` on `multiPhylo`, so every species came back as unmatched. Fixed by extracting tips from `tree[[1]]$tip.label` for multiPhylo and `tree$tip.label` for phylo.

2. **Grafted-tip suffix `*`** -- rtrees flags species placed at higher taxonomic ranks with `Genus_species*`. The trailing `*` made my normalised-name comparison fail. Strip the `*` before normalising.

3. **print method crashed on multiPhylo** -- the cli template `internal node{?s}` evaluated `tree$Nnode` which is `NULL` on multiPhylo. Rewrote the print method to dispatch on `inherits(x$tree, "multiPhylo")` and use a simpler scalar template.

## Verification

- [x] `devtools::test()` -- 2182 pass
- [x] `devtools::check(args = "--as-cran")` -- 0 errors / 0 warnings / 0 notes
- [x] Live: rtrees fish (3/3 matched), bird multiPhylo (3/3 matched after fix), mammal (2/3 matched, T-rex correctly flagged unmatched)

## Couldn't live-test

* **rotl** -- current Rcpp release removed `loadRcppModules()` and rotl crashes on namespace load. The function correctly emits its "package not available" migration error in this case. This is an upstream rotl/Rcpp incompatibility, not our bug.
* **clootl** -- `clootl::extractTree()` requires `clootl::get_avesdata_repo()` to download the ~GB AvesData repo first. Deferred to Ayumi's user-side testing per #42.