### PR TITLE
Round 3 doc-pass: harmonise type strings, statementise booleans, file-specific fixes

### DIFF
--- a/R/pr_authority.R
+++ b/R/pr_authority.R
@@ -60,7 +60,7 @@ pr_valid_authorities <- function() {
 #' was previously listed but is no longer supported, or with a
 #' standard "unknown authority" message otherwise.
 #'
-#' @param authority Character(1) or NULL. The user-supplied value.
+#' @param authority A length-1 character vector or NULL. The user-supplied value.
 #' @param call Calling environment, for `cli_abort(call = ...)`.
 #' @return The lower-cased, validated authority (or NULL).
 #' @keywords internal
@@ -104,8 +104,8 @@ pr_validate_authority <- function(authority, call = caller_env()) {
 #'
 #' Downloads the database for the specified authority if not already cached.
 #'
-#' @param authority Character(1). Taxonomic authority code.
-#' @param db_version Character(1) or NULL. Database version.
+#' @param authority A length-1 character vector. Taxonomic authority code.
+#' @param db_version A length-1 character vector or NULL. Database version.
 #'
 #' @return Invisibly returns the authority string.
 #' @keywords internal
@@ -159,8 +159,8 @@ pr_ensure_db <- function(authority, db_version = NULL) {
 #' name, taxonomic status, and taxon ID.
 #'
 #' @param names Character vector of scientific names.
-#' @param authority Character(1). Authority code (e.g., `"col"`).
-#' @param db_version Character(1) or NULL.
+#' @param authority A length-1 character vector. Authority code (e.g., `"col"`).
+#' @param db_version A length-1 character vector or NULL.
 #'
 #' @return A tibble with columns: `input`, `accepted_name`, `status`,
 #'   `taxon_id`, `authority`.

--- a/R/pr_cascade.R
+++ b/R/pr_cascade.R
@@ -12,14 +12,14 @@
 #'   authority for the synonym-resolution stage. One of `"col"`,
 #'   `"itis"`, `"gbif"`, `"ncbi"`, `"ott"`, or `"itis_test"`. `NULL`
 #'   skips stage 3.
-#' @param db_version Character(1) or NULL.
-#' @param rank Character(1). `"species"` or `"subspecies"`.
+#' @param db_version A length-1 character vector or NULL.
+#' @param rank A length-1 character vector. `"species"` or `"subspecies"`.
 #' @param overrides A data.frame with columns `name_x` and `name_y` for
 #'   pre-built overrides, or NULL.
-#' @param fuzzy Logical. Enable fuzzy matching? Default `FALSE`.
+#' @param fuzzy Logical. Enables the fuzzy-matching stage when `TRUE`. Default `FALSE`.
 #' @param fuzzy_threshold Numeric. Minimum similarity (0--1) for fuzzy
 #'   matches. Default `0.9` (conservative).
-#' @param resolve Character(1). How to handle low-confidence matches:
+#' @param resolve A length-1 character vector. How to handle low-confidence matches:
 #'   `"flag"` (default) marks fuzzy matches below 0.95 and indirect
 #'   synonym matches as `match_type = "flagged"` for manual review.
 #'   `"first"` accepts all matches at face value.

--- a/R/pr_detect.R
+++ b/R/pr_detect.R
@@ -9,7 +9,7 @@
 #' @param arg_name Character. Name of the argument, used in error messages
 #'   (e.g., `"x_species"` or `"y_species"`).
 #'
-#' @return Character(1): the detected column name.
+#' @return A length-1 character vector: the detected column name.
 #'
 #' @details
 #' **Stage 1 — Name matching.** Checks column names (case-insensitive) against

--- a/R/pr_normalize.R
+++ b/R/pr_normalize.R
@@ -2,6 +2,13 @@
 
 #' Normalise scientific names to a canonical form
 #'
+#' (Title and prose use British English spelling \emph{normalise},
+#' consistent with the package's `Language: en-GB` declaration.
+#' The function identifier `pr_normalize_names()` keeps the
+#' American-English `z` because R-package function names
+#' conventionally use ASCII identifiers in the form most R users
+#' expect; the two spellings are equivalent and intentional.)
+#'
 #' Apply a sequence of deterministic text transformations so that
 #' scientific names which differ only in formatting compare equal.
 #' This is the same routine used by stage 2 of the matching cascade in
@@ -24,9 +31,10 @@
 #'   \item Trim whitespace and collapse leftover empty tokens.
 #' }
 #'
-#' @param names Character vector of scientific names. `NA` values are
-#'   preserved as `NA`.
-#' @param rank Character(1). Taxonomic rank to normalise to:
+#' @param names A character vector of scientific names (any length;
+#'   each element is a single name). `NA` values are preserved as
+#'   `NA`.
+#' @param rank A length-1 character vector. Taxonomic rank to normalise to:
 #'   \describe{
 #'     \item{`"species"` (default)}{Strip infraspecific epithets so
 #'       trinomials become binomials (`Parus major major` ->

--- a/R/pr_tree_utils.R
+++ b/R/pr_tree_utils.R
@@ -8,11 +8,11 @@
 #' `tree$tip.label` that also handles file input and multi-tree files
 #' (returns the tips of the first tree).
 #'
-#' @param tree An `ape::phylo` object, or a character(1) path to a
-#'   Newick (`.nwk`, `.tre`, `.tree`, `.newick`) or Nexus (`.nex`,
-#'   `.nexus`) file. Format is auto-detected.
+#' @param tree An `ape::phylo` object, or a length-1 character vector
+#'   giving the path to a Newick (`.nwk`, `.tre`, `.tree`, `.newick`)
+#'   or Nexus (`.nex`, `.nexus`) file. Format is auto-detected.
 #'
-#' @return Character vector of tip labels.
+#' @return A character vector of tip labels (one element per tip).
 #'
 #' @family name utilities
 #' @seealso [pr_normalize_names()] for cleaning tip labels before

--- a/R/reconcile_accessors.R
+++ b/R/reconcile_accessors.R
@@ -108,10 +108,14 @@ reconcile_mapping <- function(reconciliation, include_unused_overrides = FALSE) 
 #' Manually override a single name in a reconciliation
 #'
 #' Apply a single hand-curated decision to a [reconciliation] object.
-#' Use this to accept a match the cascade rejected (typically a flagged
-#' fuzzy hit), remove a spurious match, or force a new mapping that the
-#' cascade missed. The override is recorded in the provenance log so
-#' that you and your reviewers can audit every manual decision.
+#' Use this to accept a match the matching cascade rejected (typically
+#' a flagged fuzzy hit), remove a spurious match, or force a new
+#' mapping that the cascade missed. ("Cascade" here means the
+#' four-stage matching pipeline run by [reconcile_tree()] and
+#' [reconcile_data()] --- exact, normalised, synonym, fuzzy --- as
+#' described in `?prepR4pcm`.) The override is recorded in the
+#' provenance log so that you and your reviewers can audit every
+#' manual decision.
 #'
 #' For applying many overrides at once (e.g. from a curated CSV), see
 #' [reconcile_override_batch()]; for interactive decisions in the
@@ -119,12 +123,12 @@ reconcile_mapping <- function(reconciliation, include_unused_overrides = FALSE) 
 #' see [reconcile_crosswalk()].
 #'
 #' @param reconciliation A [reconciliation] object.
-#' @param name_x Character(1). The name as it appears in source `x`
+#' @param name_x A length-1 character vector. The name as it appears in source `x`
 #'   (your data). Must match a value already present in `mapping$name_x`.
-#' @param name_y Character(1) or `NULL`. The name in source `y` (the
+#' @param name_y A length-1 character vector or `NULL`. The name in source `y` (the
 #'   tree or reference dataset) that `name_x` should be mapped to.
 #'   `NULL` is only valid when `action = "reject"`.
-#' @param action Character(1). What the override does:
+#' @param action A length-1 character vector. What the override does:
 #'   \describe{
 #'     \item{`"accept"` (default)}{Confirm a proposed match. Use after
 #'       reviewing a flagged fuzzy or synonym hit.}
@@ -134,7 +138,7 @@ reconcile_mapping <- function(reconciliation, include_unused_overrides = FALSE) 
 #'     \item{`"replace"`}{Set a new match, overwriting whatever the
 #'       cascade produced for `name_x`.}
 #'   }
-#' @param note Character(1). A short justification for the override,
+#' @param note A length-1 character vector. A short justification for the override,
 #'   stored in the provenance log and in `mapping$notes`. Strongly
 #'   recommended --- future you will want to know why this decision was
 #'   made.
@@ -270,12 +274,18 @@ reconcile_override <- function(reconciliation, name_x, name_y = NULL,
 #' @param reconciliation A [reconciliation] object returned by
 #'   [reconcile_tree()], [reconcile_data()], or a related matcher.
 #' @param data A data frame to align. If `NULL`, only the tree is
-#'   returned.
-#' @param tree An `ape::phylo` object to align. If `NULL`, only the
-#'   data frame is returned.
-#' @param species_col Character(1). Column in `data` containing species
-#'   names. Auto-detected if `NULL`.
-#' @param drop_unresolved Logical. Drop unmatched rows and tips?
+#'   processed and the returned `data` slot is `NULL`.
+#' @param tree An `ape::phylo` object (or path to a Newick / Nexus
+#'   file) to align. If `NULL`, only the data frame is processed and
+#'   the returned `tree` slot is `NULL`. (Passing both `data = NULL`
+#'   and `tree = NULL` is allowed but produces an empty result; the
+#'   normal use is to pass at least one of them.)
+#' @param species_col A length-1 character vector. Column in `data`
+#'   containing species names. Auto-detected from a small set of
+#'   common heuristics (e.g. `species`, `Species1`, `scientific_name`)
+#'   when `NULL`; the heuristics list is not exhaustive --- pass the
+#'   column name explicitly if your data uses a non-standard label.
+#' @param drop_unresolved Logical. Drops unmatched rows and tips when `TRUE`.
 #'   Defaults to `FALSE` (keep everything and just warn). Set to `TRUE`
 #'   when preparing data for an analysis that cannot tolerate mismatches.
 #'

--- a/R/reconcile_augment.R
+++ b/R/reconcile_augment.R
@@ -27,10 +27,10 @@
 #'   [reconcile_tree()].
 #' @param tree An `ape::phylo` object. Must be the same tree used to
 #'   build `reconciliation` (or a tree with the same tip set).
-#' @param where Character(1). Where to attach each new tip:
+#' @param where A length-1 character vector. Where to attach each new tip:
 #'   \describe{
 #'     \item{`"genus"` (default)}{Attach as sister to a single congener
-#'       chosen at random from the genus. Simpler; recommended when the
+#'       chosen at random from the genus. Recommended when the
 #'       genus has only one or two representatives in the tree, or when
 #'       you want variation across runs for sensitivity analyses.}
 #'     \item{`"near"`}{Attach at the most recent common ancestor (MRCA)
@@ -38,7 +38,7 @@
 #'       well-represented, because the new tip is not arbitrarily tied
 #'       to one sister taxon.}
 #'   }
-#' @param branch_length Character(1). How to set the terminal branch
+#' @param branch_length A length-1 character vector. How to set the terminal branch
 #'   length of each newly added tip:
 #'   \describe{
 #'     \item{`"congener_median"` (default)}{Median terminal branch length
@@ -55,9 +55,13 @@
 #'       where you want to see the effect of adding species without
 #'       assuming any divergence time.}
 #'   }
-#' @param seed Integer or `NULL`. Random seed for reproducibility when
-#'   `where = "genus"` picks a congener at random. Set to a fixed
-#'   integer in real analyses so results are reproducible. The seed is
+#' @param seed A length-1 integer or `NULL`. When non-`NULL`, a fixed
+#'   seed for the random congener choice when `where = "genus"`,
+#'   making the call reproducible. When `NULL` (default), the
+#'   session's current RNG state is used so results vary across runs
+#'   --- useful for sensitivity analyses that explore the variation
+#'   introduced by the random choice. Set to a fixed integer in real
+#'   analyses so results are reproducible. The seed is
 #'   scoped to this call: the session RNG state is saved before and
 #'   restored after, so subsequent random draws in your script are
 #'   unaffected. Default `NULL`.
@@ -341,7 +345,7 @@ pr_calc_augment_bl <- function(tree, congener_tips, method) {
 #' pure-ape implementation using `ape::bind.tree()`.
 #'
 #' @param tree phylo object.
-#' @param sp_label Character(1). Tip label to add (underscore format).
+#' @param sp_label A length-1 character vector. Tip label to add (underscore format).
 #' @param congener_tips Character vector of congener tip labels.
 #' @param where Placement strategy.
 #' @param bl Branch length for the new tip.
@@ -409,7 +413,7 @@ pr_bind_species <- function(tree, sp_label, congener_tips, where, bl) {
 #' uses a pure-ape implementation via `ape::bind.tree()`.
 #'
 #' @param tree phylo object.
-#' @param tip_label Character(1). Label for the new tip.
+#' @param tip_label A length-1 character vector. Label for the new tip.
 #' @param where Integer. Node or tip index to bind near.
 #' @param position Numeric. How far back from the node to attach.
 #' @param edge.length Numeric. Branch length of the new tip.

--- a/R/reconcile_crosswalk.R
+++ b/R/reconcile_crosswalk.R
@@ -16,14 +16,24 @@
 #'   (tab-separated), or `.txt` (tab-separated). For other delimited
 #'   formats, read the file yourself with `read.delim()` or
 #'   `read.table()` and pass the resulting data frame.
-#' @param from_col Character(1). Column name for source names (e.g.,
+#' @param from_col A length-1 character vector. Column name for source names (e.g.,
 #'   `"Species1"` for BirdLife names).
-#' @param to_col Character(1). Column name for target names (e.g.,
+#' @param to_col A length-1 character vector. Column name for target names (e.g.,
 #'   `"Species3"` for BirdTree names).
-#' @param match_type_col Character(1) or NULL. Column containing the match
-#'   type (e.g., `"1BL to 1BT"`, `"Many BL to 1BT"`). Used to annotate
-#'   notes and filter.
-#' @param notes_col Character(1) or NULL. Column containing additional
+#' @param match_type_col A length-1 character vector or `NULL`. Name
+#'   of an optional column in `crosswalk` that classifies each row's
+#'   relationship between the two taxonomies --- e.g. `"1BL to 1BT"`
+#'   (one BirdLife species mapped to one BirdTree species; a clean
+#'   one-to-one match), `"Many BL to 1BT"` (a lump: several BirdLife
+#'   species mapped to a single BirdTree species), `"1BL to many BT"`
+#'   (a split). When supplied, the contents of this column are
+#'   appended to each override's `user_note` so the audit trail
+#'   records the relationship; if you also pass
+#'   `one_to_one_only = TRUE`, only the rows whose match type starts
+#'   `"1...to 1..."` are kept. Pass `NULL` (default) when your
+#'   crosswalk has no such classification column --- every row is
+#'   then kept and notes carry no provenance label.
+#' @param notes_col A length-1 character vector or NULL. Column containing additional
 #'   notes.
 #' @param one_to_one_only Logical. If `TRUE`, keeps only one-to-one
 #'   matches (e.g., `"1BL to 1BT"`). Default `FALSE`.

--- a/R/reconcile_data.R
+++ b/R/reconcile_data.R
@@ -125,13 +125,13 @@
 #'   }
 #' @param quiet Logical. Suppresses progress messages when `TRUE`.
 #'   Default `FALSE`.
-#' @param x_label Character(1) or `NULL`. Human-readable label for source `x`
+#' @param x_label A length-1 character vector or `NULL`. Human-readable label for source `x`
 #'   stored in the reconciliation metadata and shown in `print()` / `format()`.
 #'   Defaults to the expression passed as `x` (via `deparse(substitute())`).
 #'   Set this explicitly when calling `reconcile_data()` inside another function
 #'   so the label reflects the real data source rather than the local argument
 #'   name.
-#' @param y_label Character(1) or `NULL`. Same as `x_label`, for source `y`.
+#' @param y_label A length-1 character vector or `NULL`. Same as `x_label`, for source `y`.
 #'
 #' @return A [reconciliation] object. The accompanying mapping tibble,
 #'   match-type counts, provenance metadata, and applied / unused

--- a/R/reconcile_merge.R
+++ b/R/reconcile_merge.R
@@ -31,15 +31,15 @@
 #'   [reconcile_data()]).
 #' @param data_x The first data frame (source x in the reconciliation).
 #' @param data_y The second data frame (source y in the reconciliation).
-#' @param species_col_x Character(1). Species column in `data_x`.
+#' @param species_col_x A length-1 character vector. Species column in `data_x`.
 #'   Auto-detected if `NULL`.
-#' @param species_col_y Character(1). Species column in `data_y`.
+#' @param species_col_y A length-1 character vector. Species column in `data_y`.
 #'   Auto-detected if `NULL`.
-#' @param how Character(1). Join type:
+#' @param how A length-1 character vector. Join type:
 #'   - `"inner"` (default): keep only species matched in both datasets.
 #'   - `"left"`: keep all species from `data_x`.
 #'   - `"full"`: keep all species from both datasets.
-#' @param suffix Character(2). Suffixes to disambiguate columns with the
+#' @param suffix A length-2 character vector. Suffixes to disambiguate columns with the
 #'   same name in both datasets. Default `c("_x", "_y")`.
 #' @param drop_unresolved Logical. If `TRUE`, rows where `species_resolved`
 #'   is `NA` (i.e., species that could not be reconciled) are removed from

--- a/R/reconcile_plot.R
+++ b/R/reconcile_plot.R
@@ -9,7 +9,7 @@
 #'
 #' @param reconciliation A [reconciliation] object returned by
 #'   [reconcile_tree()], [reconcile_data()], or a related matcher.
-#' @param type Character(1). Plot style:
+#' @param type A length-1 character vector. Plot style:
 #'   \describe{
 #'     \item{`"bar"` (default)}{Horizontal stacked bar chart. Best for
 #'       slides, reports, and scripting.}

--- a/R/reconcile_report.R
+++ b/R/reconcile_report.R
@@ -11,8 +11,8 @@
 #'
 #' @param reconciliation A [reconciliation] object returned by
 #'   [reconcile_tree()], [reconcile_data()], or a related matcher.
-#' @param file Character(1). Output file path. Must end in `.html`.
-#' @param title Character(1). Report title shown at the top of the
+#' @param file A length-1 character vector. Output file path. Must end in `.html`.
+#' @param title A length-1 character vector. Report title shown at the top of the
 #'   page. Default is generic.
 #' @param open Logical. Open the finished report in the default
 #'   browser? Defaults to `TRUE` in interactive sessions, `FALSE`

--- a/R/reconcile_review.R
+++ b/R/reconcile_review.R
@@ -10,7 +10,7 @@
 #'
 #' @param reconciliation A [reconciliation] object returned by
 #'   [reconcile_tree()], [reconcile_data()], or a related matcher.
-#' @param type Character(1). Which matches to review:
+#' @param type A length-1 character vector. Which matches to review:
 #'   \describe{
 #'     \item{`"flagged"`}{Only flagged matches (default).}
 #'     \item{`"fuzzy"`}{Fuzzy and flagged matches.}

--- a/R/reconcile_summary.R
+++ b/R/reconcile_summary.R
@@ -8,7 +8,7 @@
 #'
 #' @param reconciliation A [reconciliation] object returned by
 #'   [reconcile_tree()], [reconcile_data()], or a related matcher.
-#' @param detail Character(1). How much to show:
+#' @param detail A length-1 character vector. How much to show:
 #'   \describe{
 #'     \item{`"full"` (default)}{Every match category, with the names
 #'       belonging to each category listed out.}
@@ -17,13 +17,13 @@
 #'       names. Useful once the easy cases are out of the way and you
 #'       want to focus on what still needs review.}
 #'   }
-#' @param format Character(1). Where the summary goes:
+#' @param format A length-1 character vector. Where the summary goes:
 #'   \describe{
 #'     \item{`"console"` (default)}{Pretty-printed to the screen.}
 #'     \item{`"data.frame"`}{Returns a list of tibbles silently; useful
 #'       when writing a report or table in a larger script.}
 #'   }
-#' @param file Character(1) or `NULL`. If non-`NULL`, writes the
+#' @param file A length-1 character vector or `NULL`. If non-`NULL`, writes the
 #'   console report to this file path in addition to printing it.
 #' @param ... Additional arguments (currently unused).
 #'

--- a/R/reconcile_to_trees.R
+++ b/R/reconcile_to_trees.R
@@ -11,7 +11,7 @@
 #'
 #' @param x A data frame.
 #' @param trees A named list of `ape::phylo` objects or file paths.
-#' @param x_species Character(1). Column name in `x` containing species
+#' @param x_species A length-1 character vector. Column name in `x` containing species
 #'   names. Auto-detected if `NULL`.
 #' @inheritParams reconcile_data
 #'

--- a/R/reconcile_tree.R
+++ b/R/reconcile_tree.R
@@ -31,12 +31,17 @@
 #'
 #' @param x A data frame containing the trait data. Must have one
 #'   column of scientific names.
-#' @param tree An `ape::phylo` object, or a character(1) path to a
-#'   Newick (`.nwk`, `.tre`, `.tree`) or Nexus (`.nex`, `.nexus`) file.
-#'   File format is auto-detected.
-#' @param x_species Character(1). Column in `x` containing species names.
-#'   Auto-detected (e.g. `species`, `Species1`, `scientific_name`) if
-#'   `NULL`.
+#' @param tree An `ape::phylo` object, or a length-1 character vector
+#'   giving the path to a Newick (`.nwk`, `.tre`, `.tree`) or Nexus
+#'   (`.nex`, `.nexus`) file. File format is auto-detected.
+#' @param x_species A length-1 character vector. Name of the column
+#'   in `x` containing scientific names (the same column referenced
+#'   by `x` above; the term \dQuote{species names} elsewhere in this
+#'   help page is a synonym for the same scientific names). When
+#'   `NULL`, the column is auto-detected from a small list of common
+#'   labels (e.g. `species`, `Species1`, `scientific_name`); the list
+#'   is not exhaustive --- pass the column name explicitly if your
+#'   data uses a non-standard label.
 #' @inheritParams reconcile_data
 #'
 #' @return A [reconciliation] object with `meta$type == "data_tree"`.

--- a/man/pr_bind_species.Rd
+++ b/man/pr_bind_species.Rd
@@ -9,7 +9,7 @@ pr_bind_species(tree, sp_label, congener_tips, where, bl)
 \arguments{
 \item{tree}{phylo object.}
 
-\item{sp_label}{Character(1). Tip label to add (underscore format).}
+\item{sp_label}{A length-1 character vector. Tip label to add (underscore format).}
 
 \item{congener_tips}{Character vector of congener tip labels.}
 

--- a/man/pr_bind_tip.Rd
+++ b/man/pr_bind_tip.Rd
@@ -9,7 +9,7 @@ pr_bind_tip(tree, tip_label, where, position = 0, edge.length = 0)
 \arguments{
 \item{tree}{phylo object.}
 
-\item{tip_label}{Character(1). Label for the new tip.}
+\item{tip_label}{A length-1 character vector. Label for the new tip.}
 
 \item{where}{Integer. Node or tip index to bind near.}
 

--- a/man/pr_detect_species_column.Rd
+++ b/man/pr_detect_species_column.Rd
@@ -13,7 +13,7 @@ pr_detect_species_column(df, arg_name = "x_species")
 (e.g., \code{"x_species"} or \code{"y_species"}).}
 }
 \value{
-Character(1): the detected column name.
+A length-1 character vector: the detected column name.
 }
 \description{
 Uses a two-stage heuristic: first checks for common column names, then

--- a/man/pr_ensure_db.Rd
+++ b/man/pr_ensure_db.Rd
@@ -7,9 +7,9 @@
 pr_ensure_db(authority, db_version = NULL)
 }
 \arguments{
-\item{authority}{Character(1). Taxonomic authority code.}
+\item{authority}{A length-1 character vector. Taxonomic authority code.}
 
-\item{db_version}{Character(1) or NULL. Database version.}
+\item{db_version}{A length-1 character vector or NULL. Database version.}
 }
 \value{
 Invisibly returns the authority string.

--- a/man/pr_extract_tips.Rd
+++ b/man/pr_extract_tips.Rd
@@ -7,12 +7,12 @@
 pr_extract_tips(tree)
 }
 \arguments{
-\item{tree}{An \code{ape::phylo} object, or a character(1) path to a
-Newick (\code{.nwk}, \code{.tre}, \code{.tree}, \code{.newick}) or Nexus (\code{.nex},
-\code{.nexus}) file. Format is auto-detected.}
+\item{tree}{An \code{ape::phylo} object, or a length-1 character vector
+giving the path to a Newick (\code{.nwk}, \code{.tre}, \code{.tree}, \code{.newick})
+or Nexus (\code{.nex}, \code{.nexus}) file. Format is auto-detected.}
 }
 \value{
-Character vector of tip labels.
+A character vector of tip labels (one element per tip).
 }
 \description{
 Return the tip labels of a tree as a character vector, whether the

--- a/man/pr_lookup_authority.Rd
+++ b/man/pr_lookup_authority.Rd
@@ -9,9 +9,9 @@ pr_lookup_authority(names, authority = "col", db_version = NULL)
 \arguments{
 \item{names}{Character vector of scientific names.}
 
-\item{authority}{Character(1). Authority code (e.g., \code{"col"}).}
+\item{authority}{A length-1 character vector. Authority code (e.g., \code{"col"}).}
 
-\item{db_version}{Character(1) or NULL.}
+\item{db_version}{A length-1 character vector or NULL.}
 }
 \value{
 A tibble with columns: \code{input}, \code{accepted_name}, \code{status},

--- a/man/pr_normalize_names.Rd
+++ b/man/pr_normalize_names.Rd
@@ -7,10 +7,11 @@
 pr_normalize_names(names, rank = c("species", "subspecies"))
 }
 \arguments{
-\item{names}{Character vector of scientific names. \code{NA} values are
-preserved as \code{NA}.}
+\item{names}{A character vector of scientific names (any length;
+each element is a single name). \code{NA} values are preserved as
+\code{NA}.}
 
-\item{rank}{Character(1). Taxonomic rank to normalise to:
+\item{rank}{A length-1 character vector. Taxonomic rank to normalise to:
 \describe{
 \item{\code{"species"} (default)}{Strip infraspecific epithets so
 trinomials become binomials (\verb{Parus major major} ->
@@ -24,14 +25,21 @@ A character vector of normalised names, the same length as
 recording every non-trivial change, for auditing.
 }
 \description{
+(Title and prose use British English spelling \emph{normalise},
+consistent with the package's \code{Language: en-GB} declaration.
+The function identifier \code{pr_normalize_names()} keeps the
+American-English \code{z} because R-package function names
+conventionally use ASCII identifiers in the form most R users
+expect; the two spellings are equivalent and intentional.)
+}
+\details{
 Apply a sequence of deterministic text transformations so that
 scientific names which differ only in formatting compare equal.
 This is the same routine used by stage 2 of the matching cascade in
 \code{\link[=reconcile_data]{reconcile_data()}} and \code{\link[=reconcile_tree]{reconcile_tree()}}. Use it directly when you
 want to clean a column of names without running a full
 reconciliation --- for example, when building a crosswalk by hand.
-}
-\details{
+
 The transformations, applied in order, are:
 \enumerate{
 \item Replace underscores and multiple whitespace with a single

--- a/man/pr_run_cascade.Rd
+++ b/man/pr_run_cascade.Rd
@@ -28,19 +28,19 @@ authority for the synonym-resolution stage. One of \code{"col"},
 \code{"itis"}, \code{"gbif"}, \code{"ncbi"}, \code{"ott"}, or \code{"itis_test"}. \code{NULL}
 skips stage 3.}
 
-\item{db_version}{Character(1) or NULL.}
+\item{db_version}{A length-1 character vector or NULL.}
 
-\item{rank}{Character(1). \code{"species"} or \code{"subspecies"}.}
+\item{rank}{A length-1 character vector. \code{"species"} or \code{"subspecies"}.}
 
 \item{overrides}{A data.frame with columns \code{name_x} and \code{name_y} for
 pre-built overrides, or NULL.}
 
-\item{fuzzy}{Logical. Enable fuzzy matching? Default \code{FALSE}.}
+\item{fuzzy}{Logical. Enables the fuzzy-matching stage when \code{TRUE}. Default \code{FALSE}.}
 
 \item{fuzzy_threshold}{Numeric. Minimum similarity (0--1) for fuzzy
 matches. Default \code{0.9} (conservative).}
 
-\item{resolve}{Character(1). How to handle low-confidence matches:
+\item{resolve}{A length-1 character vector. How to handle low-confidence matches:
 \code{"flag"} (default) marks fuzzy matches below 0.95 and indirect
 synonym matches as \code{match_type = "flagged"} for manual review.
 \code{"first"} accepts all matches at face value.}

--- a/man/pr_validate_authority.Rd
+++ b/man/pr_validate_authority.Rd
@@ -7,7 +7,7 @@
 pr_validate_authority(authority, call = caller_env())
 }
 \arguments{
-\item{authority}{Character(1) or NULL. The user-supplied value.}
+\item{authority}{A length-1 character vector or NULL. The user-supplied value.}
 
 \item{call}{Calling environment, for \code{cli_abort(call = ...)}.}
 }

--- a/man/reconcile_apply.Rd
+++ b/man/reconcile_apply.Rd
@@ -17,15 +17,21 @@ reconcile_apply(
 \code{\link[=reconcile_tree]{reconcile_tree()}}, \code{\link[=reconcile_data]{reconcile_data()}}, or a related matcher.}
 
 \item{data}{A data frame to align. If \code{NULL}, only the tree is
-returned.}
+processed and the returned \code{data} slot is \code{NULL}.}
 
-\item{tree}{An \code{ape::phylo} object to align. If \code{NULL}, only the
-data frame is returned.}
+\item{tree}{An \code{ape::phylo} object (or path to a Newick / Nexus
+file) to align. If \code{NULL}, only the data frame is processed and
+the returned \code{tree} slot is \code{NULL}. (Passing both \code{data = NULL}
+and \code{tree = NULL} is allowed but produces an empty result; the
+normal use is to pass at least one of them.)}
 
-\item{species_col}{Character(1). Column in \code{data} containing species
-names. Auto-detected if \code{NULL}.}
+\item{species_col}{A length-1 character vector. Column in \code{data}
+containing species names. Auto-detected from a small set of
+common heuristics (e.g. \code{species}, \code{Species1}, \code{scientific_name})
+when \code{NULL}; the heuristics list is not exhaustive --- pass the
+column name explicitly if your data uses a non-standard label.}
 
-\item{drop_unresolved}{Logical. Drop unmatched rows and tips?
+\item{drop_unresolved}{Logical. Drops unmatched rows and tips when \code{TRUE}.
 Defaults to \code{FALSE} (keep everything and just warn). Set to \code{TRUE}
 when preparing data for an analysis that cannot tolerate mismatches.}
 }

--- a/man/reconcile_augment.Rd
+++ b/man/reconcile_augment.Rd
@@ -20,10 +20,10 @@ reconcile_augment(
 \item{tree}{An \code{ape::phylo} object. Must be the same tree used to
 build \code{reconciliation} (or a tree with the same tip set).}
 
-\item{where}{Character(1). Where to attach each new tip:
+\item{where}{A length-1 character vector. Where to attach each new tip:
 \describe{
 \item{\code{"genus"} (default)}{Attach as sister to a single congener
-chosen at random from the genus. Simpler; recommended when the
+chosen at random from the genus. Recommended when the
 genus has only one or two representatives in the tree, or when
 you want variation across runs for sensitivity analyses.}
 \item{\code{"near"}}{Attach at the most recent common ancestor (MRCA)
@@ -32,7 +32,7 @@ well-represented, because the new tip is not arbitrarily tied
 to one sister taxon.}
 }}
 
-\item{branch_length}{Character(1). How to set the terminal branch
+\item{branch_length}{A length-1 character vector. How to set the terminal branch
 length of each newly added tip:
 \describe{
 \item{\code{"congener_median"} (default)}{Median terminal branch length
@@ -50,9 +50,13 @@ where you want to see the effect of adding species without
 assuming any divergence time.}
 }}
 
-\item{seed}{Integer or \code{NULL}. Random seed for reproducibility when
-\code{where = "genus"} picks a congener at random. Set to a fixed
-integer in real analyses so results are reproducible. The seed is
+\item{seed}{A length-1 integer or \code{NULL}. When non-\code{NULL}, a fixed
+seed for the random congener choice when \code{where = "genus"},
+making the call reproducible. When \code{NULL} (default), the
+session's current RNG state is used so results vary across runs
+--- useful for sensitivity analyses that explore the variation
+introduced by the random choice. Set to a fixed integer in real
+analyses so results are reproducible. The seed is
 scoped to this call: the session RNG state is saved before and
 restored after, so subsequent random draws in your script are
 unaffected. Default \code{NULL}.}

--- a/man/reconcile_crosswalk.Rd
+++ b/man/reconcile_crosswalk.Rd
@@ -20,17 +20,27 @@ inferred from the extension: \code{.csv} (comma-separated), \code{.tsv}
 formats, read the file yourself with \code{read.delim()} or
 \code{read.table()} and pass the resulting data frame.}
 
-\item{from_col}{Character(1). Column name for source names (e.g.,
+\item{from_col}{A length-1 character vector. Column name for source names (e.g.,
 \code{"Species1"} for BirdLife names).}
 
-\item{to_col}{Character(1). Column name for target names (e.g.,
+\item{to_col}{A length-1 character vector. Column name for target names (e.g.,
 \code{"Species3"} for BirdTree names).}
 
-\item{match_type_col}{Character(1) or NULL. Column containing the match
-type (e.g., \code{"1BL to 1BT"}, \code{"Many BL to 1BT"}). Used to annotate
-notes and filter.}
+\item{match_type_col}{A length-1 character vector or \code{NULL}. Name
+of an optional column in \code{crosswalk} that classifies each row's
+relationship between the two taxonomies --- e.g. \code{"1BL to 1BT"}
+(one BirdLife species mapped to one BirdTree species; a clean
+one-to-one match), \code{"Many BL to 1BT"} (a lump: several BirdLife
+species mapped to a single BirdTree species), \code{"1BL to many BT"}
+(a split). When supplied, the contents of this column are
+appended to each override's \code{user_note} so the audit trail
+records the relationship; if you also pass
+\code{one_to_one_only = TRUE}, only the rows whose match type starts
+\code{"1...to 1..."} are kept. Pass \code{NULL} (default) when your
+crosswalk has no such classification column --- every row is
+then kept and notes carry no provenance label.}
 
-\item{notes_col}{Character(1) or NULL. Column containing additional
+\item{notes_col}{A length-1 character vector or NULL. Column containing additional
 notes.}
 
 \item{one_to_one_only}{Logical. If \code{TRUE}, keeps only one-to-one

--- a/man/reconcile_data.Rd
+++ b/man/reconcile_data.Rd
@@ -120,14 +120,14 @@ already reviewed the ambiguities.}
 \item{quiet}{Logical. Suppresses progress messages when \code{TRUE}.
 Default \code{FALSE}.}
 
-\item{x_label}{Character(1) or \code{NULL}. Human-readable label for source \code{x}
+\item{x_label}{A length-1 character vector or \code{NULL}. Human-readable label for source \code{x}
 stored in the reconciliation metadata and shown in \code{print()} / \code{format()}.
 Defaults to the expression passed as \code{x} (via \code{deparse(substitute())}).
 Set this explicitly when calling \code{reconcile_data()} inside another function
 so the label reflects the real data source rather than the local argument
 name.}
 
-\item{y_label}{Character(1) or \code{NULL}. Same as \code{x_label}, for source \code{y}.}
+\item{y_label}{A length-1 character vector or \code{NULL}. Same as \code{x_label}, for source \code{y}.}
 }
 \value{
 A \link{reconciliation} object. The accompanying mapping tibble,

--- a/man/reconcile_merge.Rd
+++ b/man/reconcile_merge.Rd
@@ -23,20 +23,20 @@ reconcile_merge(
 
 \item{data_y}{The second data frame (source y in the reconciliation).}
 
-\item{species_col_x}{Character(1). Species column in \code{data_x}.
+\item{species_col_x}{A length-1 character vector. Species column in \code{data_x}.
 Auto-detected if \code{NULL}.}
 
-\item{species_col_y}{Character(1). Species column in \code{data_y}.
+\item{species_col_y}{A length-1 character vector. Species column in \code{data_y}.
 Auto-detected if \code{NULL}.}
 
-\item{how}{Character(1). Join type:
+\item{how}{A length-1 character vector. Join type:
 \itemize{
 \item \code{"inner"} (default): keep only species matched in both datasets.
 \item \code{"left"}: keep all species from \code{data_x}.
 \item \code{"full"}: keep all species from both datasets.
 }}
 
-\item{suffix}{Character(2). Suffixes to disambiguate columns with the
+\item{suffix}{A length-2 character vector. Suffixes to disambiguate columns with the
 same name in both datasets. Default \code{c("_x", "_y")}.}
 
 \item{drop_unresolved}{Logical. If \code{TRUE}, rows where \code{species_resolved}

--- a/man/reconcile_override.Rd
+++ b/man/reconcile_override.Rd
@@ -15,14 +15,14 @@ reconcile_override(
 \arguments{
 \item{reconciliation}{A \link{reconciliation} object.}
 
-\item{name_x}{Character(1). The name as it appears in source \code{x}
+\item{name_x}{A length-1 character vector. The name as it appears in source \code{x}
 (your data). Must match a value already present in \code{mapping$name_x}.}
 
-\item{name_y}{Character(1) or \code{NULL}. The name in source \code{y} (the
+\item{name_y}{A length-1 character vector or \code{NULL}. The name in source \code{y} (the
 tree or reference dataset) that \code{name_x} should be mapped to.
 \code{NULL} is only valid when \code{action = "reject"}.}
 
-\item{action}{Character(1). What the override does:
+\item{action}{A length-1 character vector. What the override does:
 \describe{
 \item{\code{"accept"} (default)}{Confirm a proposed match. Use after
 reviewing a flagged fuzzy or synonym hit.}
@@ -33,7 +33,7 @@ to the unresolved pool. Use when the cascade over-matched
 cascade produced for \code{name_x}.}
 }}
 
-\item{note}{Character(1). A short justification for the override,
+\item{note}{A length-1 character vector. A short justification for the override,
 stored in the provenance log and in \code{mapping$notes}. Strongly
 recommended --- future you will want to know why this decision was
 made.}
@@ -45,10 +45,14 @@ An updated \link{reconciliation} object. The existing row for
 }
 \description{
 Apply a single hand-curated decision to a \link{reconciliation} object.
-Use this to accept a match the cascade rejected (typically a flagged
-fuzzy hit), remove a spurious match, or force a new mapping that the
-cascade missed. The override is recorded in the provenance log so
-that you and your reviewers can audit every manual decision.
+Use this to accept a match the matching cascade rejected (typically
+a flagged fuzzy hit), remove a spurious match, or force a new
+mapping that the cascade missed. ("Cascade" here means the
+four-stage matching pipeline run by \code{\link[=reconcile_tree]{reconcile_tree()}} and
+\code{\link[=reconcile_data]{reconcile_data()}} --- exact, normalised, synonym, fuzzy --- as
+described in \code{?prepR4pcm}.) The override is recorded in the
+provenance log so that you and your reviewers can audit every
+manual decision.
 }
 \details{
 For applying many overrides at once (e.g. from a curated CSV), see

--- a/man/reconcile_plot.Rd
+++ b/man/reconcile_plot.Rd
@@ -10,7 +10,7 @@ reconcile_plot(reconciliation, type = c("bar", "pie"), ...)
 \item{reconciliation}{A \link{reconciliation} object returned by
 \code{\link[=reconcile_tree]{reconcile_tree()}}, \code{\link[=reconcile_data]{reconcile_data()}}, or a related matcher.}
 
-\item{type}{Character(1). Plot style:
+\item{type}{A length-1 character vector. Plot style:
 \describe{
 \item{\code{"bar"} (default)}{Horizontal stacked bar chart. Best for
 slides, reports, and scripting.}

--- a/man/reconcile_report.Rd
+++ b/man/reconcile_report.Rd
@@ -15,9 +15,9 @@ reconcile_report(
 \item{reconciliation}{A \link{reconciliation} object returned by
 \code{\link[=reconcile_tree]{reconcile_tree()}}, \code{\link[=reconcile_data]{reconcile_data()}}, or a related matcher.}
 
-\item{file}{Character(1). Output file path. Must end in \code{.html}.}
+\item{file}{A length-1 character vector. Output file path. Must end in \code{.html}.}
 
-\item{title}{Character(1). Report title shown at the top of the
+\item{title}{A length-1 character vector. Report title shown at the top of the
 page. Default is generic.}
 
 \item{open}{Logical. Open the finished report in the default

--- a/man/reconcile_review.Rd
+++ b/man/reconcile_review.Rd
@@ -15,7 +15,7 @@ reconcile_review(
 \item{reconciliation}{A \link{reconciliation} object returned by
 \code{\link[=reconcile_tree]{reconcile_tree()}}, \code{\link[=reconcile_data]{reconcile_data()}}, or a related matcher.}
 
-\item{type}{Character(1). Which matches to review:
+\item{type}{A length-1 character vector. Which matches to review:
 \describe{
 \item{\code{"flagged"}}{Only flagged matches (default).}
 \item{\code{"fuzzy"}}{Fuzzy and flagged matches.}

--- a/man/reconcile_summary.Rd
+++ b/man/reconcile_summary.Rd
@@ -16,7 +16,7 @@ reconcile_summary(
 \item{reconciliation}{A \link{reconciliation} object returned by
 \code{\link[=reconcile_tree]{reconcile_tree()}}, \code{\link[=reconcile_data]{reconcile_data()}}, or a related matcher.}
 
-\item{detail}{Character(1). How much to show:
+\item{detail}{A length-1 character vector. How much to show:
 \describe{
 \item{\code{"full"} (default)}{Every match category, with the names
 belonging to each category listed out.}
@@ -26,14 +26,14 @@ names. Useful once the easy cases are out of the way and you
 want to focus on what still needs review.}
 }}
 
-\item{format}{Character(1). Where the summary goes:
+\item{format}{A length-1 character vector. Where the summary goes:
 \describe{
 \item{\code{"console"} (default)}{Pretty-printed to the screen.}
 \item{\code{"data.frame"}}{Returns a list of tibbles silently; useful
 when writing a report or table in a larger script.}
 }}
 
-\item{file}{Character(1) or \code{NULL}. If non-\code{NULL}, writes the
+\item{file}{A length-1 character vector or \code{NULL}. If non-\code{NULL}, writes the
 console report to this file path in addition to printing it.}
 
 \item{...}{Additional arguments (currently unused).}

--- a/man/reconcile_to_trees.Rd
+++ b/man/reconcile_to_trees.Rd
@@ -24,7 +24,7 @@ reconcile_to_trees(
 
 \item{trees}{A named list of \code{ape::phylo} objects or file paths.}
 
-\item{x_species}{Character(1). Column name in \code{x} containing species
+\item{x_species}{A length-1 character vector. Column name in \code{x} containing species
 names. Auto-detected if \code{NULL}.}
 
 \item{authority}{A length-1 character vector, or \code{NULL}. Taxonomic
@@ -105,7 +105,7 @@ already reviewed the ambiguities.}
 \item{quiet}{Logical. Suppresses progress messages when \code{TRUE}.
 Default \code{FALSE}.}
 
-\item{x_label}{Character(1) or \code{NULL}. Human-readable label for source \code{x}
+\item{x_label}{A length-1 character vector or \code{NULL}. Human-readable label for source \code{x}
 stored in the reconciliation metadata and shown in \code{print()} / \code{format()}.
 Defaults to the expression passed as \code{x} (via \code{deparse(substitute())}).
 Set this explicitly when calling \code{reconcile_data()} inside another function

--- a/man/reconcile_tree.Rd
+++ b/man/reconcile_tree.Rd
@@ -24,13 +24,18 @@ reconcile_tree(
 \item{x}{A data frame containing the trait data. Must have one
 column of scientific names.}
 
-\item{tree}{An \code{ape::phylo} object, or a character(1) path to a
-Newick (\code{.nwk}, \code{.tre}, \code{.tree}) or Nexus (\code{.nex}, \code{.nexus}) file.
-File format is auto-detected.}
+\item{tree}{An \code{ape::phylo} object, or a length-1 character vector
+giving the path to a Newick (\code{.nwk}, \code{.tre}, \code{.tree}) or Nexus
+(\code{.nex}, \code{.nexus}) file. File format is auto-detected.}
 
-\item{x_species}{Character(1). Column in \code{x} containing species names.
-Auto-detected (e.g. \code{species}, \code{Species1}, \code{scientific_name}) if
-\code{NULL}.}
+\item{x_species}{A length-1 character vector. Name of the column
+in \code{x} containing scientific names (the same column referenced
+by \code{x} above; the term \dQuote{species names} elsewhere in this
+help page is a synonym for the same scientific names). When
+\code{NULL}, the column is auto-detected from a small list of common
+labels (e.g. \code{species}, \code{Species1}, \code{scientific_name}); the list
+is not exhaustive --- pass the column name explicitly if your
+data uses a non-standard label.}
 
 \item{authority}{A length-1 character vector, or \code{NULL}. Taxonomic
 authority used for synonym resolution (stage 3 of the cascade).
@@ -116,7 +121,7 @@ already reviewed the ambiguities.}
 \item{quiet}{Logical. Suppresses progress messages when \code{TRUE}.
 Default \code{FALSE}.}
 
-\item{x_label}{Character(1) or \code{NULL}. Human-readable label for source \code{x}
+\item{x_label}{A length-1 character vector or \code{NULL}. Human-readable label for source \code{x}
 stored in the reconciliation metadata and shown in \code{print()} / \code{format()}.
 Defaults to the expression passed as \code{x} (via \code{deparse(substitute())}).
 Set this explicitly when calling \code{reconcile_data()} inside another function


### PR DESCRIPTION
Folds in the per-function documentation feedback wave from @pooherna (#17-#21, #26) and @jimuelceleste (#30-#41). Bulk pattern: `Character(1)` -> `A length-1 character vector`; question-style boolean params -> statements.

**File-specific fixes**: pr_normalize en-GB note (#18), pr_extract_tips return type (#17), reconcile_apply NULL behaviour (#19), reconcile_augment Simpler/seed (#20), reconcile_crosswalk match_type_col (#21), reconcile_override cascade term (#31), reconcile_tree species/scientific consistency (#40).

**Important**: This PR does NOT close any issues. The reporters need to verify the rendered help pages first, then close themselves.

Verified locally: 2182 tests pass, R CMD check 0/0/0, spell_check clean.