### PR TITLE
Tier 4: 5 future-proofing tests for bugs that already shipped (223 claim-parity tests total)

### DIFF
--- a/tests/testthat/test-claim-deployed-url-pattern.R
+++ b/tests/testthat/test-claim-deployed-url-pattern.R
@@ -1,0 +1,55 @@
+# Bundle G #42 -- deployed-site URL patterns
+#
+# When pkgdown sites are served at `<owner>.github.io/<repo>/`, the
+# correct URL for an article is `/articles/<name>.html` -- NOT
+# `/docs/articles/<name>.html`. The `/docs/` segment is the
+# repository directory; GitHub Pages serves it from the root and the
+# `/docs/` part is internal.
+#
+# Round-3 caught a README that linked to
+# `https://itchyshin.github.io/prepR4pcm/docs/articles/...` -- those
+# were 404s. This test fails the build if anyone reintroduces the
+# pattern.
+
+test_that("no `/docs/articles/` or `/docs/reference/` URLs in user-facing files", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  files <- c(
+    file.path(root, "README.Rmd"),
+    file.path(root, "README.md"),
+    list.files(file.path(root, "vignettes"),
+               pattern = "\\.Rmd$", full.names = TRUE),
+    file.path(root, "_pkgdown.yml")
+  )
+  files <- files[file.exists(files)]
+  if (length(files) == 0) skip("no user-facing files found")
+
+  bad_lines <- character()
+  pat <- "https?://[^/]*itchyshin\\.github\\.io/prepR4pcm/docs/(articles|reference)/"
+  for (f in files) {
+    src <- readLines(f, warn = FALSE)
+    for (i in seq_along(src)) {
+      if (grepl(pat, src[i], perl = TRUE)) {
+        bad_lines <- c(
+          bad_lines,
+          sprintf("%s:%d: %s", basename(f), i, trimws(src[i]))
+        )
+      }
+    }
+  }
+
+  expect_equal(
+    length(bad_lines), 0,
+    info = paste0(
+      "Found `/docs/articles/` or `/docs/reference/` URLs (these 404 on the deployed site).",
+      " Use `/articles/...` and `/reference/...` instead:\n  ",
+      paste(head(bad_lines, 20), collapse = "\n  "),
+      if (length(bad_lines) > 20)
+        sprintf("\n  ... and %d more", length(bad_lines) - 20)
+      else ""
+    )
+  )
+})

--- a/tests/testthat/test-claim-doi-resolves-to-claimed-paper.R
+++ b/tests/testthat/test-claim-doi-resolves-to-claimed-paper.R
@@ -1,0 +1,117 @@
+# Bundle G #44 -- DOI resolves to a paper whose title plausibly
+# matches what the help page claims.
+#
+# Caught in PR #28: our `delhey_subset` Rd cited Delhey 2019
+# *American Naturalist* 194:13-27 with `doi:10.1086/703588`. The
+# DOI was wrong -- it resolves to a 2018 book review of
+# *Synthetic Biology: A Very Short Introduction* in *Quarterly
+# Review of Biology*. The format-only DOI test passed because the
+# DOI string was syntactically valid; the live HEAD-check passed
+# because the URL existed. Neither caught the title mismatch.
+#
+# This test queries Crossref's API for each `@source`/`@references`
+# DOI in the package and asserts that the returned title contains
+# at least one keyword from the dataset's claimed citation. Catches
+# the next "DOI points at a different paper" bug.
+
+# Live test: skip on CRAN, skip if offline.
+
+# A small allowlist of {DOI -> keywords that must appear in the
+# Crossref title} entries. Keep the keyword list short (1-3 words);
+# the test passes if ANY of the listed keywords appear (case-
+# insensitive) in the resolved title.
+.doi_keyword_map <- list(
+  # Bird datasets
+  `10.1111/ele.13898`         = c("AVONET", "ecological"),       # Tobias 2022
+  `10.1038/s41597-023-02837-1`= c("nest", "global"),              # Chia 2023
+  `10.1111/ele.13233`         = c("ecogeographical", "rainfall"), # Delhey 2019
+  `10.1038/nature11631`       = c("global diversity", "birds"),   # Jetz 2012
+  # taxadb / ape
+  `10.1111/2041-210X.13440`   = c("taxadb", "taxonomic"),         # Norman 2020
+  `10.1093/bioinformatics/bty633` = c("ape 5.0", "phylogenetics"), # Paradis & Schliep 2019
+  # Mammal datasets
+  `10.1890/15-0846R.1`        = c("amniote", "life-history"),     # Myhrvold 2015
+  `10.1890/08-1494.1`         = c("PanTHERIA", "mammals"),        # Jones 2009
+  `10.1371/journal.pbio.3002658` = c("tetrapod", "traits"),       # Moura 2024
+  # Mammal phylogeny references
+  `10.1371/journal.pbio.3000494` = c("mammal", "tree"),           # Upham 2019
+  `10.1016/j.ympev.2014.11.001`  = c("mammal", "extinct"),        # Faurby & Svenning 2015
+  `10.1038/nature05634`          = c("delayed", "mammals")        # Bininda-Emonds 2007
+)
+
+
+test_that("each DOI in the @source allowlist resolves to a paper whose title matches the expected topic", {
+  skip_on_cran()
+  testthat::skip_if_offline()
+
+  for (doi in names(.doi_keyword_map)) {
+    keywords <- .doi_keyword_map[[doi]]
+    url <- paste0("https://api.crossref.org/works/", doi)
+    title <- tryCatch(
+      {
+        raw <- system(
+          paste0("curl -s --max-time 15 ", shQuote(url)),
+          intern = TRUE
+        )
+        if (length(raw) == 0 || !nzchar(paste(raw, collapse = ""))) {
+          return(NA_character_)
+        }
+        # Cheap JSON title extraction: find "title":["..."] pattern
+        joined <- paste(raw, collapse = " ")
+        m <- regmatches(joined,
+                        regexpr('"title":\\s*\\[\\s*"[^"]+"', joined,
+                                perl = TRUE))
+        if (length(m) == 0 || !nzchar(m)) return(NA_character_)
+        sub('^"title":\\s*\\[\\s*"', "", m)
+      },
+      error = function(e) NA_character_
+    )
+
+    if (is.na(title)) {
+      skip(sprintf("Crossref unavailable for DOI %s", doi))
+    }
+
+    matched <- any(vapply(
+      keywords,
+      function(k) grepl(k, title, ignore.case = TRUE, fixed = FALSE),
+      logical(1)
+    ))
+    expect_true(
+      matched,
+      info = sprintf(
+        "DOI %s resolves to paper titled '%s' but the help page citation claims a topic matching one of: %s",
+        doi, substr(title, 1, 100),
+        paste(keywords, collapse = ", ")
+      )
+    )
+  }
+})
+
+
+test_that("every DOI cited in R/data.R appears in the keyword allowlist", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  data_rd <- file.path(root, "R", "data.R")
+  if (!file.exists(data_rd)) skip("R/data.R not present")
+
+  src <- paste(readLines(data_rd, warn = FALSE), collapse = "\n")
+  doi_pattern <- "10\\.\\d{4,9}/[-._;()/:A-Z0-9a-z]+"
+  matches <- regmatches(src, gregexpr(doi_pattern, src, perl = TRUE))[[1]]
+  matches <- gsub("[).,;}]+$", "", matches)
+  matches <- unique(matches)
+
+  unallowlisted <- setdiff(matches, names(.doi_keyword_map))
+  expect_equal(
+    length(unallowlisted), 0,
+    info = paste0(
+      "DOIs cited in R/data.R but missing from .doi_keyword_map ",
+      "(in test-claim-doi-resolves-to-claimed-paper.R). Add each ",
+      "to the map with a 1-3 word keyword list so the resolution ",
+      "test exercises it:\n  ",
+      paste(unallowlisted, collapse = "\n  ")
+    )
+  )
+})

--- a/tests/testthat/test-claim-no-bare-doi.R
+++ b/tests/testthat/test-claim-no-bare-doi.R
@@ -1,0 +1,114 @@
+# Bundle G #40 -- no bare `doi:10.xxx` URIs in user-facing files
+#
+# Catches the bug shipped in PR #28 where vignettes used `doi:10.xxx`
+# as plain text. Pandoc renders these as href="doi:10.xxx" which the
+# browser treats as a custom URI scheme -- effectively dead links on
+# the deployed site. The fix is to wrap them in markdown links:
+# `[doi:10.xxx](https://doi.org/10.xxx)`.
+#
+# This test scans every .Rmd / README.md for bare doi: outside of a
+# completed markdown link. If any survive, the deployed site has dead
+# links.
+
+test_that("no bare doi: URIs in user-facing files (issue: PR #28 regression)", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  files <- c(
+    file.path(root, "README.Rmd"),
+    file.path(root, "README.md"),
+    list.files(file.path(root, "vignettes"),
+               pattern = "\\.Rmd$", full.names = TRUE)
+  )
+  files <- files[file.exists(files)]
+  if (length(files) == 0) skip("no user-facing markdown files found")
+
+  bad_lines <- character()
+  for (f in files) {
+    src <- readLines(f, warn = FALSE)
+    for (i in seq_along(src)) {
+      line <- src[i]
+      # Look for a `doi:10.xxx` substring whose preceding char is
+      # NOT `]`+`(` (markdown link) and NOT inside `[...]` brackets.
+      # Cheap heuristic: every `doi:10.` must have a preceding `[`
+      # OR be inside `()` brackets that are part of `](...)`.
+      pos <- gregexpr("doi:10\\.", line, perl = TRUE)[[1]]
+      if (pos[1] == -1) next
+      for (p in pos) {
+        # Inside a `[doi:...](url)` link, the doi: comes right after `[`.
+        # Inside the URL, doi: doesn't appear -- doi.org/10. does.
+        # So we accept a doi:10. ONLY if the char immediately before is `[`.
+        before <- if (p == 1) "" else substr(line, p - 1, p - 1)
+        if (before != "[") {
+          bad_lines <- c(
+            bad_lines,
+            sprintf("%s:%d: %s", basename(f), i, trimws(line))
+          )
+        }
+      }
+    }
+  }
+
+  expect_equal(
+    length(bad_lines), 0,
+    info = paste0(
+      "Bare `doi:10.xxx` URIs found (these render as dead links):\n  ",
+      paste(head(bad_lines, 20), collapse = "\n  "),
+      if (length(bad_lines) > 20)
+        sprintf("\n  ... and %d more", length(bad_lines) - 20)
+      else "",
+      "\nWrap each in a markdown link: `[doi:10.xxx](https://doi.org/10.xxx)`."
+    )
+  )
+})
+
+
+test_that("every `[doi:X](url/Y)` has X == Y (regression for PR #29 truncation)", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  files <- c(
+    file.path(root, "README.Rmd"),
+    file.path(root, "README.md"),
+    list.files(file.path(root, "vignettes"),
+               pattern = "\\.Rmd$", full.names = TRUE)
+  )
+  files <- files[file.exists(files)]
+  if (length(files) == 0) skip("no user-facing markdown files found")
+
+  mismatches <- character()
+  for (f in files) {
+    src <- paste(readLines(f, warn = FALSE), collapse = "\n")
+    matches <- regmatches(
+      src,
+      gregexpr("\\[doi:([^]]+)\\]\\(https://doi\\.org/([^)]+)\\)",
+               src, perl = TRUE)
+    )[[1]]
+    for (m in matches) {
+      parts <- regmatches(
+        m,
+        regexec("\\[doi:([^]]+)\\]\\(https://doi\\.org/([^)]+)\\)",
+                m, perl = TRUE)
+      )[[1]]
+      if (length(parts) >= 3 && parts[2] != parts[3]) {
+        mismatches <- c(
+          mismatches,
+          sprintf("%s: text=`%s` url=`%s`",
+                  basename(f), parts[2], parts[3])
+        )
+      }
+    }
+  }
+
+  expect_equal(
+    length(mismatches), 0,
+    info = paste0(
+      "Markdown DOI links where the visible text and URL disagree (likely a regex truncation bug):\n  ",
+      paste(mismatches, collapse = "\n  ")
+    )
+  )
+})

--- a/tests/testthat/test-claim-roxygen-style.R
+++ b/tests/testthat/test-claim-roxygen-style.R
@@ -1,0 +1,102 @@
+# Bundle G #41 -- roxygen style consistency
+#
+# Two patterns the round-3 doc-pass eliminated, each documented
+# pooherna+jimuelceleste cross-function feedback (issues #17-#21,
+# #26, #30-#41):
+#
+#   1. `Character(N)` -- ambiguous between "single character" and
+#      "length-N character vector". Replace with the unambiguous
+#      "A length-N character vector".
+#
+#   2. `Logical. Verb-with-question-mark?` -- e.g.
+#      `Logical. Suppress progress messages?`. Reads as a
+#      yes/no quiz instead of a parameter description. Replace
+#      with statement form: `Logical. Suppresses ... when TRUE.`
+#
+# Both patterns crept across many help pages without test coverage.
+# These tests fail the build if anyone reintroduces either pattern in
+# `R/*.R` roxygen blocks.
+
+test_that("no `Character(N)` type strings in R/ roxygen", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  r_files <- list.files(file.path(root, "R"),
+                         pattern = "\\.R$", full.names = TRUE)
+  if (length(r_files) == 0) skip("R/ source not accessible")
+
+  bad <- character()
+  for (f in r_files) {
+    src <- readLines(f, warn = FALSE)
+    for (i in seq_along(src)) {
+      line <- src[i]
+      # Match only inside roxygen comment lines (`#'`).
+      if (!grepl("^#'", line)) next
+      if (grepl("Character\\(\\d+\\)", line, perl = TRUE)) {
+        bad <- c(bad, sprintf("%s:%d: %s", basename(f), i, trimws(line)))
+      }
+    }
+  }
+
+  expect_equal(
+    length(bad), 0,
+    info = paste0(
+      "Found `Character(N)` type strings in R/*.R roxygen blocks. ",
+      "Replace each with 'A length-N character vector' for clarity ",
+      "(@pooherna / @jimuelceleste convention from issues #17-#41):\n  ",
+      paste(head(bad, 20), collapse = "\n  "),
+      if (length(bad) > 20)
+        sprintf("\n  ... and %d more", length(bad) - 20)
+      else ""
+    )
+  )
+})
+
+
+test_that("no `Logical. <Verb>...?` question-style boolean param descriptions", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  r_files <- list.files(file.path(root, "R"),
+                         pattern = "\\.R$", full.names = TRUE)
+  if (length(r_files) == 0) skip("R/ source not accessible")
+
+  # Pattern: a roxygen `@param X Logical. <Verb...>?` line, where the
+  # text after "Logical." ends with `?` before any further sentence
+  # terminator. We're flexible about whitespace and word count.
+  bad <- character()
+  for (f in r_files) {
+    src <- readLines(f, warn = FALSE)
+    for (i in seq_along(src)) {
+      line <- src[i]
+      if (!grepl("^#'\\s+@param\\s+\\w+\\s+Logical\\.", line, perl = TRUE)) {
+        next
+      }
+      # Look for `?` ending a sentence within the line.
+      # Allow lines that end with `Default ...`/`Defaults ...`/`when TRUE.`.
+      tail <- sub("^.*Logical\\.\\s*", "", line)
+      first_sentence <- sub("[.!?].*$", "\\0", tail)
+      if (grepl("\\?$", first_sentence, perl = TRUE)) {
+        bad <- c(bad, sprintf("%s:%d: %s", basename(f), i, trimws(line)))
+      }
+    }
+  }
+
+  expect_equal(
+    length(bad), 0,
+    info = paste0(
+      "Found question-style boolean @param descriptions (e.g. ",
+      "`Logical. Suppress messages?`). Rephrase as a statement: ",
+      "`Logical. Suppresses messages when TRUE.` ",
+      "(@pooherna / @jimuelceleste convention from issues #17-#41):\n  ",
+      paste(head(bad, 20), collapse = "\n  "),
+      if (length(bad) > 20)
+        sprintf("\n  ... and %d more", length(bad) - 20)
+      else ""
+    )
+  )
+})

--- a/tests/testthat/test-claim-suggests-remotes-consistency.R
+++ b/tests/testthat/test-claim-suggests-remotes-consistency.R
@@ -1,0 +1,137 @@
+# Bundle G #43 -- Suggests-vs-Remotes consistency
+#
+# CI failed in PR #43 / PR #44 because `clootl` and `rtrees` are
+# GitHub-only Suggests but had no `Remotes:` entry, so pak couldn't
+# resolve them during dependency setup. The fix was to declare them
+# in the `Remotes:` field. This test catches the same drift in the
+# future: every Suggests / Imports package that is NOT on CRAN and
+# NOT in `Remotes:` will fail the build.
+#
+# We approximate "is on CRAN" via a static allowlist of known CRAN
+# packages used by this project, since hitting the CRAN API on every
+# test is slow and CI-fragile. If a NEW non-CRAN dependency is added
+# that isn't on this allowlist, the test fails -- forcing the
+# developer to either confirm it's on CRAN or add it to the
+# `Remotes:` field.
+
+# Packages we know are on CRAN (any release year). When adding a new
+# Suggests / Imports package that's on CRAN, append it here.
+.cran_allowlist <- c(
+  "ape", "cli", "rlang", "tibble",
+  "caper", "dplyr", "knitr", "MCMCglmm", "phytools", "pkgdown",
+  "readr", "rmarkdown", "rotl", "spelling", "stringr", "taxadb",
+  "testthat",
+  # standard packages bundled with R
+  "stats", "tools", "utils", "graphics", "grDevices", "methods"
+)
+
+
+test_that("every non-CRAN Suggests / Imports has a matching Remotes entry", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  desc <- read.dcf(file.path(root, "DESCRIPTION"))
+  parse_field <- function(name) {
+    v <- desc[1, name]
+    if (is.na(v)) return(character())
+    parts <- trimws(strsplit(v, ",")[[1]])
+    parts <- gsub("\\s*\\([^)]*\\)\\s*$", "", parts)  # strip "(>= ...)"
+    parts <- gsub(",\\s*$", "", parts)
+    parts[nzchar(parts)]
+  }
+
+  imports  <- parse_field("Imports")
+  suggests <- parse_field("Suggests")
+  depends  <- parse_field("Depends")
+  # `Depends` may include `R (>= ...)` -- strip `R` itself
+  depends <- depends[depends != "R"]
+  remotes <- parse_field("Remotes")
+
+  # Strip `github::owner/` prefix and any `@ref` suffix so we get
+  # the bare package name from `Remotes:`.
+  remotes_pkgs <- vapply(remotes, function(r) {
+    r <- sub(".*::", "", r)         # drop `github::` etc.
+    r <- sub("/.*$", "", sub("^[^/]+/", "", paste0(r, "/")))
+    r
+  }, character(1))
+  # Better: just take the part after the last `/`.
+  remotes_pkgs <- vapply(remotes, function(r) {
+    r <- sub(".*::", "", r)
+    parts <- strsplit(r, "/", fixed = TRUE)[[1]]
+    parts[length(parts)]
+  }, character(1))
+  remotes_pkgs <- sub("@.*$", "", remotes_pkgs)
+
+  declared <- c(imports, suggests, depends)
+
+  unaccounted <- setdiff(declared, c(.cran_allowlist, remotes_pkgs))
+  expect_equal(
+    length(unaccounted), 0,
+    info = paste0(
+      "Imports / Suggests / Depends entries that are neither on the ",
+      "CRAN allowlist nor in `Remotes:`. Either add them to the ",
+      "allowlist (in this test file) or to the DESCRIPTION's ",
+      "`Remotes:` field so pak can resolve them on CI:\n  ",
+      paste(unaccounted, collapse = "\n  ")
+    )
+  )
+})
+
+
+# A Remotes entry can legitimately exist for a transitive
+# dependency: pak needs to know where to fetch the transitive
+# package even when our package doesn't directly Import / Suggest
+# it. This allowlist holds those transitive-only Remotes; add
+# entries when you add a Remotes that backs a transitive dep.
+.transitive_remotes_allowlist <- c(
+  # `rtrees` (Suggests) depends on `megatrees`. Listed in our
+  # Remotes so pak can fetch megatrees when installing rtrees on CI.
+  "megatrees"
+)
+
+
+test_that("every Remotes entry corresponds to a real Imports / Suggests / Depends or is allowlisted as transitive", {
+  skip_on_cran()
+
+  root <- .claim_root()
+  if (is.na(root)) skip("source tree not accessible")
+
+  desc <- read.dcf(file.path(root, "DESCRIPTION"))
+  parse_field <- function(name) {
+    v <- desc[1, name]
+    if (is.na(v)) return(character())
+    parts <- trimws(strsplit(v, ",")[[1]])
+    parts <- gsub("\\s*\\([^)]*\\)\\s*$", "", parts)
+    parts <- gsub(",\\s*$", "", parts)
+    parts[nzchar(parts)]
+  }
+
+  remotes <- parse_field("Remotes")
+  if (length(remotes) == 0) skip("no Remotes field")
+
+  declared <- c(parse_field("Imports"),
+                parse_field("Suggests"),
+                parse_field("Depends"))
+
+  remotes_pkgs <- vapply(remotes, function(r) {
+    r <- sub(".*::", "", r)
+    parts <- strsplit(r, "/", fixed = TRUE)[[1]]
+    parts[length(parts)]
+  }, character(1))
+  remotes_pkgs <- sub("@.*$", "", remotes_pkgs)
+
+  orphans <- setdiff(remotes_pkgs,
+                     c(declared, .transitive_remotes_allowlist))
+  expect_equal(
+    length(orphans), 0,
+    info = paste0(
+      "Packages in `Remotes:` that are NEITHER in Imports / Suggests / ",
+      "Depends NOR on the transitive-Remotes allowlist (in this test ",
+      "file). Each Remotes entry should back a real declared dependency, ",
+      "or be flagged as transitive in `.transitive_remotes_allowlist`:\n  ",
+      paste(orphans, collapse = "\n  ")
+    )
+  )
+})


### PR DESCRIPTION
Five new test files. Each top-of-file comment names the specific bug it would have caught. Note the PR title intentionally avoids `closes #N` -- these tests are meta-protections, not closures of the doc-feedback issues themselves (those stay open until reporters confirm the rendered help pages).

| Test | Bug it would have caught |
|---|---|
| test-claim-no-bare-doi.R | Bare `doi:10.xxx` URIs in vignettes (PR #28); truncated DOIs from regex (PR #29) |
| test-claim-roxygen-style.R | `Character(N)` ambiguity (24 issues from pooherna + jimuelceleste); question-style boolean param descriptions (12 issues) |
| test-claim-deployed-url-pattern.R | `/docs/articles/` URLs in README that 404'd on deploy (PR #28) |
| test-claim-suggests-remotes-consistency.R | clootl/rtrees in Suggests but not Remotes -> CI failure (PR #43); transitive megatrees Remotes (PR #44) |
| test-claim-doi-resolves-to-claimed-paper.R | Wrong Delhey DOI pointing at "Synthetic Biology" book review (PR #28); silent DOI drift in future |

Total claim-parity tests now: 223 across 20 files.

Verification:
- devtools::test() -- all 223 claim-parity + 2182 unit tests pass
- devtools::check(--as-cran) -- 0/0/0
- All 5 tests deliberately tested by reverting to broken state in scratch -- each fired correctly