### PR TITLE
Round 6: tree-handling UX polish (cache + status + compare + TNRS + auto dispatcher)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ Suggests:
     caper,
     clootl,
     datelife,
+    digest,
     dplyr,
     fishtree,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,37 @@
 # prepR4pcm 0.3.1.9000 (development version)
 
+## Round 6: tree-handling UX polish
+
+* **Local on-disk cache for `pr_get_tree()`.** Pass `cache = TRUE`
+  to memoise the request on disk; subsequent identical calls are
+  instant. New companion functions:
+  - `pr_tree_cache_dir(path = NULL)` -- get/set the cache directory.
+    Defaults to `tools::R_user_dir()`; can be set to a project-local
+    path so the cache travels with the analysis.
+  - `pr_tree_cache_status()` -- list cache entries with timestamps
+    and sizes.
+  - `pr_tree_cache_clear(confirm, source)` -- wipe the cache;
+    optionally restrict to a single backend.
+* **`pr_get_tree_status(check_network)` health probe.** One-call
+  report listing every backend with installed / version /
+  needs_network / reachable / install hint. Useful for first-time
+  users figuring out which backends are available.
+* **`pr_tree_compare(...)` for comparing trees.** Tip-set Jaccard,
+  Robinson-Foulds distance on the shared subtree, branch-length
+  agreement. Accepts `phylo`, `multiPhylo`, or `pr_tree_result`
+  inputs (positional or named).
+* **TNRS preflight for non-TNRS backends.** New `tnrs` argument on
+  `pr_get_tree()`: `"auto"` (default; runs TNRS for clootl + fishtree
+  to lift their match rates), `"always"` (run regardless), `"never"`
+  (skip). Silently skipped with a one-shot warning when `rotl` is
+  not installed.
+* **`source = "auto"` fall-through dispatcher.** Tries installed
+  backends in priority order; returns the first that resolves at
+  least `min_match` of the species (default 0.8) or the best of the
+  lot if none meets the threshold. New `min_match` argument
+  controls the threshold.
+* `digest` added to `Suggests` (used by the new cache-key hashing).
+
 ## Round 5: posterior-tree support and the prepR4pcm -> pigauto pipeline
 
 * **`pr_get_tree()` gains a unified `n_tree` parameter** so users can

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -118,6 +118,19 @@ reference:
   - pr_get_tree
   - pr_date_tree
   - pr_cite_tree
+  - pr_tree_compare
+
+- title: "Tree-handling utilities"
+  desc: >
+    Helpers for the `pr_get_tree()` workflow: a backend health
+    probe, an on-disk cache for repeat retrievals, and the
+    `source = "auto"` / `tnrs = "auto"` controls (see
+    `?pr_get_tree`).
+  contents:
+  - pr_get_tree_status
+  - pr_tree_cache_dir
+  - pr_tree_cache_status
+  - pr_tree_cache_clear
 
 - title: "Bundled bird data"
   desc: >

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -194,3 +194,7 @@ Syst
 walkthrough
 prepR4pcm's
 pcm's
+Foulds
+Jaccard
+memoise
+TNRS

--- a/tests/testthat/test-claim-suggests-remotes-consistency.R
+++ b/tests/testthat/test-claim-suggests-remotes-consistency.R
@@ -18,8 +18,8 @@
 # Suggests / Imports package that's on CRAN, append it here.
 .cran_allowlist <- c(
   "ape", "cli", "rlang", "tibble",
-  "caper", "dplyr", "fishtree", "knitr", "MCMCglmm", "phytools", "pkgdown",
-  "readr", "rmarkdown", "rotl", "spelling", "stringr", "taxadb",
+  "caper", "digest", "dplyr", "fishtree", "knitr", "MCMCglmm", "phytools",
+  "pkgdown", "readr", "rmarkdown", "rotl", "spelling", "stringr", "taxadb",
   "testthat",
   # standard packages bundled with R
   "stats", "tools", "utils", "graphics", "grDevices", "methods"


### PR DESCRIPTION
## Summary

Round 6 of the issue #48 plan. Five user-visible features that
make the Round 4/5 backends easier to live with day-to-day:

1. **Local on-disk cache.** `pr_get_tree(species, source = ..., cache = TRUE)`
   memoises the request keyed on `(species, source, n_tree, taxon, ...)`.
   Subsequent identical calls are instant. Companion functions:
   - `pr_tree_cache_dir(path = NULL)` -- get/set the cache dir.
     Default is `tools::R_user_dir(\"prepR4pcm\", \"cache\")`; can be
     pointed at a project-local path so the cache travels with the
     analysis.
   - `pr_tree_cache_status()` -- list entries with timestamps.
   - `pr_tree_cache_clear(confirm, source)` -- wipe the cache.

2. **`pr_get_tree_status()` health probe.** One-call report of which
   backends are installed, at what version, whether they need
   network, and what to install to fix any gaps.

3. **`pr_tree_compare(...)` for comparing trees.** Pairwise tip-set
   Jaccard, Robinson-Foulds distance on the shared subtree, and
   branch-length agreement. Accepts `phylo`, `multiPhylo`, or
   `pr_tree_result` inputs (positional or named).

4. **TNRS preflight for non-TNRS backends.** New `tnrs` argument:
   `\"auto\"` (default; runs TNRS for clootl + fishtree to lift their
   match rates), `\"always\"`, `\"never\"`. Skipped with a one-shot
   warning if rotl isn't installed.

5. **`source = \"auto\"` fall-through dispatcher.** Tries installed
   backends in priority order, returns the first one that resolves
   at least `min_match` of the species (default 0.8) or the
   best-of-the-lot if none meets the threshold. Useful for first-
   pass exploration when you don't yet know which backend covers
   your taxa.

## What's NOT in this PR (deferred to Round 7+)

- TimeTree.org REST client (universal time-tree coverage; licensing
  on bulk queries is murky).
- `V.PhyloMaker` / `U.PhyloMaker` as additional `reconcile_augment(source = ...)` options (mostly subsumed by rtrees).

## Test plan

- [x] `devtools::test()` -- 2382 PASS / 2 SKIP / 0 FAIL.
- [x] `devtools::check(args = \"--as-cran\")` -- 0 errors / 0 warnings / 0 notes.
- [x] `devtools::spell_check()` -- only pre-existing flags.
- [x] `devtools::document()` -- regenerated cleanly.
- [x] pkgdown reference index covers every new export.
- [x] @seealso cross-links between new functions are reciprocal.
- [ ] @ayumimizuno or @jimuelceleste -- to verify on real datasets.
      Issue #42 stays open pending verification.

## Notes for reviewers

- Cache key is order-invariant for species but order-sensitive for
  every other arg. Test `pr_tree_cache_key is deterministic and
  species-order invariant` exercises this.
- The auto dispatcher recursively calls `pr_get_tree()` once per
  candidate backend; that's intentional to reuse the validation,
  cache, and TNRS preflight code paths.
- TNRS preflight extracts `unique_name` from `rotl::tnrs_match_names`
  -- this is what Open Tree returns as the canonical resolved name.
  When TNRS itself fails (network), the preflight silently falls
  back to the original species list.
- `pr_tree_compare()`'s branch-length correlation is a coarse
  sorted-edge-length comparison when the topologies disagree; a
  bipartition-matched correlation is a future-round refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)