### PR TITLE
Fix #53: README polish + hotfix V.PhyloMaker3 hallucination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ scripts/output/
 
 # Claude Code runtime state
 .claude/
+README.html

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,8 +64,8 @@ Suggests:
     taxadb,
     testthat (>= 3.0.0),
     U.PhyloMaker,
-    V.PhyloMaker2,
-    V.PhyloMaker3
+    V.PhyloMaker,
+    V.PhyloMaker2
 Additional_repositories:
     https://eliotmiller.r-universe.dev,
     https://daijiang.r-universe.dev,
@@ -75,8 +75,8 @@ Remotes:
     eliotmiller/clootl,
     daijiang/rtrees,
     phylotastic/datelife,
-    jinyizju/V.PhyloMaker3,
     jinyizju/V.PhyloMaker2,
+    jinyizju/V.PhyloMaker,
     jinyizju/U.PhyloMaker
 LazyData: true
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,30 @@
+# prepR4pcm 0.4.0.9000 (development version)
+
+## Bug fixes and documentation polish
+
+* `reconcile_summary()` no longer prints to the console when its
+  result is assigned to a variable. The formatted report now lives
+  on the returned object's `formatted_text` slot and renders via
+  the `print.reconciliation_summary()` method, so R's REPL
+  auto-prints the report only when the function is called at the
+  prompt without assignment. Refs #12 (Ayumi Mizuno).
+* README: rewritten the introduction to spell out *why* species-name
+  mismatches matter for PCMs, expanded the worked examples for each
+  mismatch type (formatting, synonymy, typos), expanded the PGLS /
+  PCM acronyms, moved the Quick example after Typical workflow,
+  added inline framing prose around the Quick example, fixed broken
+  / missing links for the Clements checklist and BirdLife-BirdTree
+  crosswalk, added an inline citation block (text + BibTeX) so
+  users don't need to run `citation("prepR4pcm")` to see what to
+  cite, and clarified that bundled datasets are *subsets* of the
+  full upstream sources. Refs #53 (Malgorzata Lagisz).
+* Fixed: removed `V.PhyloMaker3` from `Suggests` and `Remotes` --
+  the repo was hallucinated in Round 8 and doesn't exist on GitHub
+  (`jinyizju/V.PhyloMaker3` returns 404). The `vphylomaker` augment
+  backend now prefers `V.PhyloMaker2` (the actual current version)
+  with a fallback to the original `V.PhyloMaker`. The fix preserves
+  the public API of `reconcile_augment(source = "vphylomaker")`.
+
 # prepR4pcm 0.4.0
 
 This release closes out the multi-round tree-handling overhaul started

--- a/R/reconcile_augment.R
+++ b/R/reconcile_augment.R
@@ -43,16 +43,18 @@
 #'     reference --- which the internal mode would skip.}
 #'   \item{\code{"vphylomaker"}}{Plant-only alternative to
 #'     \code{"rtrees"} via either of the GitHub packages
-#'     \pkg{V.PhyloMaker3}
-#'     (\url{https://github.com/jinyizju/V.PhyloMaker3}, preferred
-#'     when installed) or \pkg{V.PhyloMaker2}
-#'     (\url{https://github.com/jinyizju/V.PhyloMaker2}, used as a
-#'     fallback). Calls \code{phylo.maker(sp.list, tree, scenarios = ...)}
-#'     with your tree as the backbone. Use this when you want
-#'     explicit control over the V.PhyloMaker placement scenario
-#'     (\code{"S1"}, \code{"S2"}, or \code{"S3"} --- see Jin & Qian
-#'     2019, \emph{Ecography} 42:1353); otherwise \code{"rtrees"}
-#'     with \code{taxon = "plant"} is simpler.}
+#'     \pkg{V.PhyloMaker2}
+#'     (\url{https://github.com/jinyizju/V.PhyloMaker2}, preferred
+#'     when installed; updated and enlarged version) or
+#'     \pkg{V.PhyloMaker}
+#'     (\url{https://github.com/jinyizju/V.PhyloMaker}, used as a
+#'     fallback; original 2019 version). Calls
+#'     \code{phylo.maker(sp.list, tree, scenarios = ...)} with your
+#'     tree as the backbone. Use this when you want explicit control
+#'     over the V.PhyloMaker placement scenario (\code{"S1"},
+#'     \code{"S2"}, or \code{"S3"} --- see Jin & Qian 2019/2022);
+#'     otherwise \code{"rtrees"} with \code{taxon = "plant"} is
+#'     simpler.}
 #'   \item{\code{"uphylomaker"}}{Universal (plants + animals) variant
 #'     of V.PhyloMaker, via the GitHub package \pkg{U.PhyloMaker}
 #'     (\url{https://github.com/jinyizju/U.PhyloMaker}). Same
@@ -133,7 +135,7 @@
 #'   that break ultrametricity by construction).
 #' @param ... Additional arguments forwarded to the chosen backend:
 #'   `rtrees::get_tree()` for `source = "rtrees"` (e.g. `scenario`,
-#'   `n_tree`); `V.PhyloMaker3::phylo.maker()` for
+#'   `n_tree`); `V.PhyloMaker2::phylo.maker()` for
 #'   `source = "vphylomaker"` (e.g. `scenarios = "S3"`,
 #'   `nodes.type`); `U.PhyloMaker::phylo.maker()` for
 #'   `source = "uphylomaker"` (e.g. `gen.list`, `scenario`).
@@ -728,40 +730,41 @@ pr_bind_species <- function(tree, sp_label, congener_tips, where, bl) {
 }
 
 
-#' Internal: delegate grafting to V.PhyloMaker3::phylo.maker()
+#' Internal: delegate grafting to V.PhyloMaker2::phylo.maker()
 #'
 #' Plant-only alternative to the rtrees backend. Wraps
-#' `V.PhyloMaker3::phylo.maker()` so the user can pick a specific
+#' `V.PhyloMaker2::phylo.maker()` so the user can pick a specific
 #' V.PhyloMaker scenario (S1 / S2 / S3, see Jin & Qian 2019).
 #'
 #' @param species_to_add Character vector of binomials to graft.
 #' @param tree The user's backbone phylo.
 #' @param scenarios Character. One of "S1", "S2", "S3" (default
-#'   "S3"). Forwarded to `V.PhyloMaker3::phylo.maker()`.
+#'   "S3"). Forwarded to `V.PhyloMaker2::phylo.maker()`.
 #' @param quiet Logical.
-#' @param ... Forwarded to `V.PhyloMaker3::phylo.maker()`.
+#' @param ... Forwarded to `V.PhyloMaker2::phylo.maker()`.
 #' @return A list with `tree`, `augmented`, `skipped`, `backend_meta`.
 #' @keywords internal
 .pr_augment_vphylomaker <- function(species_to_add, tree,
                                       scenarios = "S3",
                                       quiet = FALSE, ...) {
-  # Prefer V.PhyloMaker3 when available; fall back to V.PhyloMaker2.
-  # Both packages expose `phylo.maker()` with the same calling
-  # convention, so the dispatch is just choosing the namespace.
-  pkg <- if (requireNamespace("V.PhyloMaker3", quietly = TRUE)) {
-    "V.PhyloMaker3"
-  } else if (requireNamespace("V.PhyloMaker2", quietly = TRUE)) {
+  # Prefer V.PhyloMaker2 when available; fall back to V.PhyloMaker
+  # (the original). Both packages expose `phylo.maker()` with the
+  # same calling convention, so the dispatch is just choosing the
+  # namespace.
+  pkg <- if (requireNamespace("V.PhyloMaker2", quietly = TRUE)) {
     "V.PhyloMaker2"
+  } else if (requireNamespace("V.PhyloMaker", quietly = TRUE)) {
+    "V.PhyloMaker"
   } else {
     cli::cli_abort(
-      c("{.code source = \"vphylomaker\"} requires either {.pkg V.PhyloMaker3} or {.pkg V.PhyloMaker2}.",
-        "i" = 'Install V3 (preferred) with: {.code pak::pak("jinyizju/V.PhyloMaker3")}.',
-        "i" = 'Or install V2 with: {.code pak::pak("jinyizju/V.PhyloMaker2")}.',
-        ">" = "See {.url https://github.com/jinyizju/V.PhyloMaker3} for details.")
+      c("{.code source = \"vphylomaker\"} requires either {.pkg V.PhyloMaker2} or {.pkg V.PhyloMaker}.",
+        "i" = 'Install V2 (preferred) with: {.code pak::pak("jinyizju/V.PhyloMaker2")}.',
+        "i" = 'Or install V1 with: {.code pak::pak("jinyizju/V.PhyloMaker")}.',
+        ">" = "See {.url https://github.com/jinyizju/V.PhyloMaker2} for details.")
     )
   }
   if (!quiet) {
-    cli::cli_alert_info("Using {.pkg {pkg}} (preferred when both are installed: V3).")
+    cli::cli_alert_info("Using {.pkg {pkg}} (preferred when both are installed: V2).")
   }
 
   # V.PhyloMaker (both 2 and 3) wants a sp.list data.frame with cols
@@ -791,14 +794,14 @@ pr_bind_species <- function(tree, sp_label, congener_tips, where, bl) {
     cand <- pm[vapply(pm, inherits, logical(1), what = "phylo")]
     if (length(cand) == 0L) {
       cli::cli_abort(c(
-        "Unexpected return type from {.code V.PhyloMaker3::phylo.maker()}.",
+        "Unexpected return type from {.code V.PhyloMaker2::phylo.maker()}.",
         "i" = "Got names: {.val {names(pm)}}.")
       )
     }
     cand[[1]]
   } else {
     cli::cli_abort(
-      "Unexpected return type from {.code V.PhyloMaker3::phylo.maker()}: {.cls {class(pm)[1]}}."
+      "Unexpected return type from {.code V.PhyloMaker2::phylo.maker()}: {.cls {class(pm)[1]}}."
     )
   }
 
@@ -846,8 +849,8 @@ pr_bind_species <- function(tree, sp_label, congener_tips, where, bl) {
       package    = pkg,
       scenarios  = scenarios,
       references = c(
-        v3_v2 = "Jin Y & Qian H (2022) V.PhyloMaker2: an updated and enlarged R package that can generate very large phylogenies for vascular plants. Plant Diversity 44:335-339. doi:10.1016/j.pld.2022.05.005",
-        v1    = "Jin Y & Qian H (2019) V.PhyloMaker: an R package that can generate very large phylogenies for vascular plants. Ecography 42:1353-1359. doi:10.1111/ecog.04434"
+        v2 = "Jin Y & Qian H (2022) V.PhyloMaker2: an updated and enlarged R package that can generate very large phylogenies for vascular plants. Plant Diversity 44:335-339. doi:10.1016/j.pld.2022.05.005",
+        v1 = "Jin Y & Qian H (2019) V.PhyloMaker: an R package that can generate very large phylogenies for vascular plants. Ecography 42:1353-1359. doi:10.1111/ecog.04434"
       )
     )
   )

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,13 +19,30 @@ knitr::opts_chunk$set(
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
-Species names in your data rarely match the tip labels in your tree.
-Formatting differences (`Homo_sapiens` vs `Homo sapiens`), taxonomic
-synonyms, and simple typos silently drop species from phylogenetic
-comparative analyses. **prepR4pcm** detects and resolves these mismatches
-through a multi-stage matching cascade (exact, normalised, synonym, fuzzy),
-documents every decision, and produces aligned data--tree pairs ready for
-PGLS, phylogenetic mixed models, or any other PCM.
+Species names in your data rarely match the tip labels in your
+phylogenetic tree exactly. Such mismatches prevent you from
+combining species traits (data tables) with their evolutionary
+relationships (the phylogenetic tree) — which is what
+phylogenetic comparative methods (PCMs, e.g. studies of trait
+evolution, niche conservatism, or correlated trait change) need.
+Three kinds of mismatch silently drop species from these analyses:
+
+- **Formatting differences**, e.g. `Homo_sapiens` vs `Homo sapiens`,
+  trailing whitespace, capitalisation
+- **Taxonomic synonyms / different ranks**, e.g. `Homo sapiens` vs
+  `Homo sapiens sapiens`, or a recent name vs the historical
+  synonym used in the tree
+- **Simple typos**, e.g. `Homo sapiens` vs `Hamo sapiens`
+
+**prepR4pcm** detects and resolves all three through a multi-stage
+matching cascade (exact → normalised → synonym → fuzzy), documents
+every decision so the choices are auditable, and produces aligned
+data–tree pairs ready for phylogenetic generalised least squares
+(PGLS), phylogenetic mixed models (PGLMMs), or any other PCM.
+
+Below you'll find: how to install, a quick example, the typical
+workflow, vignettes covering realistic pipelines, citation
+information, and a list of the bundled example datasets.
 
 ## Installation
 
@@ -34,29 +51,6 @@ Install the development version from GitHub:
 ```r
 # install.packages("pak")
 pak::pak("itchyshin/prepR4pcm")
-```
-
-## Quick example
-
-```{r example}
-library(prepR4pcm)
-library(ape)
-
-# Reconcile a dataset against a phylogenetic tree
-rec <- reconcile_tree(
-  x         = avonet_subset,
-  tree      = tree_jetz,
-  x_species = "Species1",
-  fuzzy     = TRUE,
-  resolve   = "flag"
-)
-rec
-
-# Apply the reconciliation: aligned data + pruned tree
-aligned <- reconcile_apply(rec, data = avonet_subset, tree = tree_jetz,
-                           species_col = "Species1", drop_unresolved = TRUE)
-nrow(aligned$data)
-ape::Ntip(aligned$tree)
 ```
 
 ## Features
@@ -92,6 +86,45 @@ Load data + tree
   Aligned data + pruned tree --> PGLS / PGLMM
 ```
 
+## Quick example
+
+This minimal example reconciles a small bird trait dataset
+(`avonet_subset`, a sample of AVONET) against a small bird phylogeny
+(`tree_jetz`, a sample of the Jetz et al. 2012 phylogeny) and
+produces a model-ready aligned data frame plus a pruned tree.
+
+```{r example}
+library(prepR4pcm)
+library(ape)
+
+# Reconcile a dataset against a phylogenetic tree
+rec <- reconcile_tree(
+  x         = avonet_subset,
+  tree      = tree_jetz,
+  x_species = "Species1",
+  fuzzy     = TRUE,
+  resolve   = "flag"
+)
+rec
+
+# Apply the reconciliation: aligned data + pruned tree
+aligned <- reconcile_apply(rec, data = avonet_subset, tree = tree_jetz,
+                           species_col = "Species1", drop_unresolved = TRUE)
+nrow(aligned$data)
+ape::Ntip(aligned$tree)
+```
+
+What just happened: `reconcile_tree()` matched every species name
+in `avonet_subset$Species1` against the tip labels of `tree_jetz`,
+trying exact matches first and falling back through normalised,
+synonym, and fuzzy matches as needed. The printed `rec` object
+shows the count in each match category. `reconcile_apply()` then
+takes that reconciliation and produces (a) a data frame with rows
+restricted to species that resolved to a tree tip, and (b) the
+tree pruned to those tips. The `nrow()` and `ape::Ntip()` calls
+confirm the two sides agree on species count — the precondition
+for any downstream PGLS or PGLMM call.
+
 ## Vignettes
 
 - [Getting Started](https://itchyshin.github.io/prepR4pcm/articles/getting-started.html)
@@ -110,7 +143,31 @@ Load data + tree
 
 ## Citation
 
-If you use prepR4pcm in your research, please cite the package:
+If you use prepR4pcm in your research, please cite the package and
+the original publication for any bundled example dataset you used
+(see *Bundled data sources* below).
+
+For the package itself:
+
+> Nakagawa S, Ortega S, Mizuno A, Santos E, Lagisz M, Celeste J, Poo Hernandez S (2026).
+> *prepR4pcm: Prepare Data and Trees for Phylogenetic Comparative Methods.*
+> R package version 0.4.0. <https://github.com/itchyshin/prepR4pcm>
+
+BibTeX:
+
+```bibtex
+@Manual{,
+  title  = {prepR4pcm: Prepare Data and Trees for Phylogenetic Comparative Methods},
+  author = {Shinichi Nakagawa and Santiago Ortega and Ayumi Mizuno and
+            Eduardo S.A. Santos and Malgorzata Lagisz and Jimuel Jr Celeste and
+            Sergio {Poo Hernandez}},
+  year   = {2026},
+  note   = {R package version 0.4.0},
+  url    = {https://github.com/itchyshin/prepR4pcm},
+}
+```
+
+Or run in R to get the same entry programmatically:
 
 ```r
 citation("prepR4pcm")
@@ -126,10 +183,13 @@ citation("prepR4pcm")
 
 ## Bundled data sources
 
-The package includes subset datasets for examples, vignettes, and
-testing. Each is a small sample of a larger published dataset; if
-you use any of them in published work, please cite the original
-provider.
+The package ships small sample datasets — each is a *subset*
+(a few hundred rows or tips) of a larger published dataset, used
+only for the package's examples, vignettes, and tests. They are
+not full versions: if you want to *do science* with these data,
+download the full original dataset from the source listed below.
+If you use any of these examples in published work, please cite
+the original provider.
 
 **Bird data (used by the bird-workflow vignette):**
 
@@ -146,10 +206,12 @@ provider.
   491:444--448.
   [doi:10.1038/nature11631](https://doi.org/10.1038/nature11631)
 - **Clements checklist** (`tree_clements25`): Clements et al. (2025)
-  eBird/Clements Checklist of Birds of the World, v2025.
+  eBird/Clements Checklist of Birds of the World, v2025
+  ([https://www.birds.cornell.edu/clementschecklist/](https://www.birds.cornell.edu/clementschecklist/)).
 - **BirdLife-BirdTree crosswalk** (`crosswalk_birdlife_birdtree`):
-  Distributed with AVONET (Tobias et al. 2022); maps BirdLife
-  taxonomy to the BirdTree (Jetz et al. 2012,
+  distributed with AVONET (Tobias et al. 2022,
+  [doi:10.1111/ele.13898](https://doi.org/10.1111/ele.13898));
+  maps BirdLife taxonomy to the BirdTree (Jetz et al. 2012,
   [doi:10.1038/nature11631](https://doi.org/10.1038/nature11631))
   taxonomy.
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,30 @@
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
-Species names in your data rarely match the tip labels in your tree.
-Formatting differences (`Homo_sapiens` vs `Homo sapiens`), taxonomic
-synonyms, and simple typos silently drop species from phylogenetic
-comparative analyses. **prepR4pcm** detects and resolves these
-mismatches through a multi-stage matching cascade (exact, normalised,
-synonym, fuzzy), documents every decision, and produces aligned
-data–tree pairs ready for PGLS, phylogenetic mixed models, or any other
-PCM.
+Species names in your data rarely match the tip labels in your
+phylogenetic tree exactly. Such mismatches prevent you from combining
+species traits (data tables) with their evolutionary relationships (the
+phylogenetic tree) — which is what phylogenetic comparative methods
+(PCMs, e.g. studies of trait evolution, niche conservatism, or
+correlated trait change) need. Three kinds of mismatch silently drop
+species from these analyses:
+
+- **Formatting differences**, e.g. `Homo_sapiens` vs `Homo sapiens`,
+  trailing whitespace, capitalisation
+- **Taxonomic synonyms / different ranks**, e.g. `Homo sapiens` vs
+  `Homo sapiens sapiens`, or a recent name vs the historical synonym
+  used in the tree
+- **Simple typos**, e.g. `Homo sapiens` vs `Hamo sapiens`
+
+**prepR4pcm** detects and resolves all three through a multi-stage
+matching cascade (exact → normalised → synonym → fuzzy), documents every
+decision so the choices are auditable, and produces aligned data–tree
+pairs ready for phylogenetic generalised least squares (PGLS),
+phylogenetic mixed models (PGLMMs), or any other PCM.
+
+Below you’ll find: how to install, a quick example, the typical
+workflow, vignettes covering realistic pipelines, citation information,
+and a list of the bundled example datasets.
 
 ## Installation
 
@@ -25,59 +41,6 @@ Install the development version from GitHub:
 ``` r
 # install.packages("pak")
 pak::pak("itchyshin/prepR4pcm")
-```
-
-## Quick example
-
-``` r
-library(prepR4pcm)
-library(ape)
-
-# Reconcile a dataset against a phylogenetic tree
-rec <- reconcile_tree(
-  x         = avonet_subset,
-  tree      = tree_jetz,
-  x_species = "Species1",
-  fuzzy     = TRUE,
-  resolve   = "flag"
-)
-#> ℹ Reconciling 919 data names vs 657 tree tips
-#> ℹ Matching 919 x 657 names through 4 stages...
-#> ℹ Stage 1/4: Exact matching...
-#> ℹ Stage 2/4: Normalised matching (0 matched so far)...
-#> ℹ Stage 3/4: Synonym resolution (657 matched so far)...
-#> ℹ Stage 4/4: Fuzzy matching (657 matched so far)...
-#> ✔ Matched 657/919 data names to tree tips
-rec
-#> 
-#> ── Reconciliation: data vs tree ────────────────────────────────────────────────
-#>   Source x: avonet_subset
-#>   Source y: phylo (657 tips)
-#>   Authority: col
-#>   Timestamp: 2026-05-01 09:04:13
-#> ℹ Match coverage: [█████████████████████░░░░░░░░░] 71% (657/919)
-#> 
-#> ── Match summary ──
-#> 
-#> • Exact: 0 ( 0.0%)
-#> • Normalized: 657 (71.5%)
-#> • Synonym: 0 ( 0.0%)
-#> • Fuzzy: 0 ( 0.0%)
-#> • Manual: 0 ( 0.0%)
-#> ! Unresolved (x only):262 (28.5%)
-#> ! Unresolved (y only):0
-#> ! Flagged for review: 0
-#> ℹ Use `reconcile_summary()` for details, `reconcile_mapping()` for the full table.
-
-# Apply the reconciliation: aligned data + pruned tree
-aligned <- reconcile_apply(rec, data = avonet_subset, tree = tree_jetz,
-                           species_col = "Species1", drop_unresolved = TRUE)
-#> ! Dropped 262 rows with unresolved species from data
-#> ℹ Tree has 657 tips after alignment
-nrow(aligned$data)
-#> [1] 657
-ape::Ntip(aligned$tree)
-#> [1] 657
 ```
 
 ## Features
@@ -112,6 +75,74 @@ ape::Ntip(aligned$tree)
            |
       Aligned data + pruned tree --> PGLS / PGLMM
 
+## Quick example
+
+This minimal example reconciles a small bird trait dataset
+(`avonet_subset`, a sample of AVONET) against a small bird phylogeny
+(`tree_jetz`, a sample of the Jetz et al. 2012 phylogeny) and produces a
+model-ready aligned data frame plus a pruned tree.
+
+``` r
+library(prepR4pcm)
+library(ape)
+
+# Reconcile a dataset against a phylogenetic tree
+rec <- reconcile_tree(
+  x         = avonet_subset,
+  tree      = tree_jetz,
+  x_species = "Species1",
+  fuzzy     = TRUE,
+  resolve   = "flag"
+)
+#> ℹ Reconciling 919 data names vs 657 tree tips
+#> ℹ Matching 919 x 657 names through 4 stages...
+#> ℹ Stage 1/4: Exact matching...
+#> ℹ Stage 2/4: Normalised matching (0 matched so far)...
+#> ℹ Stage 3/4: Synonym resolution (657 matched so far)...
+#> ℹ Stage 4/4: Fuzzy matching (657 matched so far)...
+#> ✔ Matched 657/919 data names to tree tips
+rec
+#> 
+#> ── Reconciliation: data vs tree ────────────────────────────────────────────────
+#>   Source x: avonet_subset
+#>   Source y: phylo (657 tips)
+#>   Authority: col
+#>   Timestamp: 2026-05-01 14:18:01
+#> ℹ Match coverage: [█████████████████████░░░░░░░░░] 71% (657/919)
+#> 
+#> ── Match summary ──
+#> 
+#> • Exact: 0 ( 0.0%)
+#> • Normalized: 657 (71.5%)
+#> • Synonym: 0 ( 0.0%)
+#> • Fuzzy: 0 ( 0.0%)
+#> • Manual: 0 ( 0.0%)
+#> ! Unresolved (x only):262 (28.5%)
+#> ! Unresolved (y only):0
+#> ! Flagged for review: 0
+#> ℹ Use `reconcile_summary()` for details, `reconcile_mapping()` for the full table.
+
+# Apply the reconciliation: aligned data + pruned tree
+aligned <- reconcile_apply(rec, data = avonet_subset, tree = tree_jetz,
+                           species_col = "Species1", drop_unresolved = TRUE)
+#> ! Dropped 262 rows with unresolved species from data
+#> ℹ Tree has 657 tips after alignment
+nrow(aligned$data)
+#> [1] 657
+ape::Ntip(aligned$tree)
+#> [1] 657
+```
+
+What just happened: `reconcile_tree()` matched every species name in
+`avonet_subset$Species1` against the tip labels of `tree_jetz`, trying
+exact matches first and falling back through normalised, synonym, and
+fuzzy matches as needed. The printed `rec` object shows the count in
+each match category. `reconcile_apply()` then takes that reconciliation
+and produces (a) a data frame with rows restricted to species that
+resolved to a tree tip, and (b) the tree pruned to those tips. The
+`nrow()` and `ape::Ntip()` calls confirm the two sides agree on species
+count — the precondition for any downstream PGLS or PGLMM call.
+
 ## Vignettes
 
 - [Getting
@@ -131,7 +162,32 @@ ape::Ntip(aligned$tree)
 
 ## Citation
 
-If you use prepR4pcm in your research, please cite the package:
+If you use prepR4pcm in your research, please cite the package and the
+original publication for any bundled example dataset you used (see
+*Bundled data sources* below).
+
+For the package itself:
+
+> Nakagawa S, Ortega S, Mizuno A, Santos E, Lagisz M, Celeste J, Poo
+> Hernandez S (2026). *prepR4pcm: Prepare Data and Trees for
+> Phylogenetic Comparative Methods.* R package version 0.4.0.
+> <https://github.com/itchyshin/prepR4pcm>
+
+BibTeX:
+
+``` bibtex
+@Manual{,
+  title  = {prepR4pcm: Prepare Data and Trees for Phylogenetic Comparative Methods},
+  author = {Shinichi Nakagawa and Santiago Ortega and Ayumi Mizuno and
+            Eduardo S.A. Santos and Malgorzata Lagisz and Jimuel Jr Celeste and
+            Sergio {Poo Hernandez}},
+  year   = {2026},
+  note   = {R package version 0.4.0},
+  url    = {https://github.com/itchyshin/prepR4pcm},
+}
+```
+
+Or run in R to get the same entry programmatically:
 
 ``` r
 citation("prepR4pcm")
@@ -147,9 +203,12 @@ citation("prepR4pcm")
 
 ## Bundled data sources
 
-The package includes subset datasets for examples, vignettes, and
-testing. Each is a small sample of a larger published dataset; if you
-use any of them in published work, please cite the original provider.
+The package ships small sample datasets — each is a *subset* (a few
+hundred rows or tips) of a larger published dataset, used only for the
+package’s examples, vignettes, and tests. They are not full versions: if
+you want to *do science* with these data, download the full original
+dataset from the source listed below. If you use any of these examples
+in published work, please cite the original provider.
 
 **Bird data (used by the bird-workflow vignette):**
 
@@ -165,10 +224,12 @@ use any of them in published work, please cite the original provider.
   491:444–448.
   [doi:10.1038/nature11631](https://doi.org/10.1038/nature11631)
 - **Clements checklist** (`tree_clements25`): Clements et al. (2025)
-  eBird/Clements Checklist of Birds of the World, v2025.
+  eBird/Clements Checklist of Birds of the World, v2025
+  (<https://www.birds.cornell.edu/clementschecklist/>).
 - **BirdLife-BirdTree crosswalk** (`crosswalk_birdlife_birdtree`):
-  Distributed with AVONET (Tobias et al. 2022); maps BirdLife taxonomy
-  to the BirdTree (Jetz et al. 2012,
+  distributed with AVONET (Tobias et al. 2022,
+  [doi:10.1111/ele.13898](https://doi.org/10.1111/ele.13898)); maps
+  BirdLife taxonomy to the BirdTree (Jetz et al. 2012,
   [doi:10.1038/nature11631](https://doi.org/10.1038/nature11631))
   taxonomy.
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -221,3 +221,6 @@ Qian
 standalone
 TimeTree
 TimeTree's
+PGLMMs
+R's
+REPL

--- a/man/dot-pr_augment_vphylomaker.Rd
+++ b/man/dot-pr_augment_vphylomaker.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/reconcile_augment.R
 \name{.pr_augment_vphylomaker}
 \alias{.pr_augment_vphylomaker}
-\title{Internal: delegate grafting to V.PhyloMaker3::phylo.maker()}
+\title{Internal: delegate grafting to V.PhyloMaker2::phylo.maker()}
 \usage{
 .pr_augment_vphylomaker(
   species_to_add,
@@ -18,18 +18,18 @@
 \item{tree}{The user's backbone phylo.}
 
 \item{scenarios}{Character. One of "S1", "S2", "S3" (default
-"S3"). Forwarded to \code{V.PhyloMaker3::phylo.maker()}.}
+"S3"). Forwarded to \code{V.PhyloMaker2::phylo.maker()}.}
 
 \item{quiet}{Logical.}
 
-\item{...}{Forwarded to \code{V.PhyloMaker3::phylo.maker()}.}
+\item{...}{Forwarded to \code{V.PhyloMaker2::phylo.maker()}.}
 }
 \value{
 A list with \code{tree}, \code{augmented}, \code{skipped}, \code{backend_meta}.
 }
 \description{
 Plant-only alternative to the rtrees backend. Wraps
-\code{V.PhyloMaker3::phylo.maker()} so the user can pick a specific
+\code{V.PhyloMaker2::phylo.maker()} so the user can pick a specific
 V.PhyloMaker scenario (S1 / S2 / S3, see Jin & Qian 2019).
 }
 \keyword{internal}

--- a/man/reconcile_augment.Rd
+++ b/man/reconcile_augment.Rd
@@ -94,7 +94,7 @@ that break ultrametricity by construction).}
 
 \item{...}{Additional arguments forwarded to the chosen backend:
 \code{rtrees::get_tree()} for \code{source = "rtrees"} (e.g. \code{scenario},
-\code{n_tree}); \code{V.PhyloMaker3::phylo.maker()} for
+\code{n_tree}); \code{V.PhyloMaker2::phylo.maker()} for
 \code{source = "vphylomaker"} (e.g. \code{scenarios = "S3"},
 \code{nodes.type}); \code{U.PhyloMaker::phylo.maker()} for
 \code{source = "uphylomaker"} (e.g. \code{gen.list}, \code{scenario}).
@@ -166,16 +166,18 @@ genus is absent from your tree but present in \pkg{rtrees}'
 reference --- which the internal mode would skip.}
 \item{\code{"vphylomaker"}}{Plant-only alternative to
 \code{"rtrees"} via either of the GitHub packages
-\pkg{V.PhyloMaker3}
-(\url{https://github.com/jinyizju/V.PhyloMaker3}, preferred
-when installed) or \pkg{V.PhyloMaker2}
-(\url{https://github.com/jinyizju/V.PhyloMaker2}, used as a
-fallback). Calls \code{phylo.maker(sp.list, tree, scenarios = ...)}
-with your tree as the backbone. Use this when you want
-explicit control over the V.PhyloMaker placement scenario
-(\code{"S1"}, \code{"S2"}, or \code{"S3"} --- see Jin & Qian
-2019, \emph{Ecography} 42:1353); otherwise \code{"rtrees"}
-with \code{taxon = "plant"} is simpler.}
+\pkg{V.PhyloMaker2}
+(\url{https://github.com/jinyizju/V.PhyloMaker2}, preferred
+when installed; updated and enlarged version) or
+\pkg{V.PhyloMaker}
+(\url{https://github.com/jinyizju/V.PhyloMaker}, used as a
+fallback; original 2019 version). Calls
+\code{phylo.maker(sp.list, tree, scenarios = ...)} with your
+tree as the backbone. Use this when you want explicit control
+over the V.PhyloMaker placement scenario (\code{"S1"},
+\code{"S2"}, or \code{"S3"} --- see Jin & Qian 2019/2022);
+otherwise \code{"rtrees"} with \code{taxon = "plant"} is
+simpler.}
 \item{\code{"uphylomaker"}}{Universal (plants + animals) variant
 of V.PhyloMaker, via the GitHub package \pkg{U.PhyloMaker}
 (\url{https://github.com/jinyizju/U.PhyloMaker}). Same

--- a/tests/testthat/test-round8-final.R
+++ b/tests/testthat/test-round8-final.R
@@ -64,7 +64,7 @@ test_that("source = 'vphylomaker' dispatches to the helper", {
 })
 
 
-test_that("source = 'vphylomaker' errors helpfully when neither V3 nor V2 installed", {
+test_that("source = 'vphylomaker' errors helpfully when neither V2 nor V1 installed", {
   tree <- ape::rtree(2, tip.label = c("Quercus_robur", "Pinus_sylvestris"))
   df <- data.frame(species = c("Quercus robur", "Pinus sylvestris",
                                 "Quercus alba"),
@@ -75,7 +75,7 @@ test_that("source = 'vphylomaker' errors helpfully when neither V3 nor V2 instal
   )
   testthat::local_mocked_bindings(
     requireNamespace = function(package, ..., quietly = TRUE) {
-      if (package %in% c("V.PhyloMaker3", "V.PhyloMaker2")) FALSE else TRUE
+      if (package %in% c("V.PhyloMaker2", "V.PhyloMaker")) FALSE else TRUE
     },
     .package = "base"
   )
@@ -86,8 +86,8 @@ test_that("source = 'vphylomaker' errors helpfully when neither V3 nor V2 instal
   )
   expect_s3_class(err, "error")
   msg <- conditionMessage(err)
-  expect_true(grepl("V.PhyloMaker3", msg, fixed = TRUE))
   expect_true(grepl("V.PhyloMaker2", msg, fixed = TRUE))
+  expect_true(grepl("V.PhyloMaker", msg, fixed = TRUE))
 })
 
 


### PR DESCRIPTION
## Summary

Two changes bundled because they overlap on `DESCRIPTION` /
`reconcile_augment.R`:

### 1. README polish (#53, Malgorzata Lagisz)

Per Mal's checklist:
- Rewrote the introduction to spell out **why** species-name
  mismatches matter for PCMs (the so-what question her item 1
  raised).
- Expanded the worked examples for each mismatch type
  (formatting / synonymy / typos).
- Expanded the PGLS / PCM acronyms on first use.
- Moved Quick example after Typical workflow.
- Added framing prose around Quick example explaining what it
  does and what the user should see.
- Fixed missing links for the Clements checklist and BirdLife-
  BirdTree crosswalk.
- Replaced the bare \`citation(\"prepR4pcm\")\` snippet with an
  inline text + BibTeX citation so users can copy directly.
- Clarified that bundled datasets are *subsets* of upstream sources.

### 2. Hotfix: V.PhyloMaker3 doesn't exist (Round 8 regression)

The repo \`jinyizju/V.PhyloMaker3\` was hallucinated in Round 8
(it returns 404). Removed from \`Suggests:\` and \`Remotes:\`. The
\`vphylomaker\` augment backend now prefers V.PhyloMaker2 (the
actual current version) with V.PhyloMaker (original) as the
fallback. Public API of \`reconcile_augment(source = \"vphylomaker\")\`
is unchanged.

Caught by trying \`devtools::build_readme()\`, which exposed the bad
Remotes entry.

## Test plan

- [x] \`devtools::test()\` -- 2458 PASS / 2 SKIP / 0 FAIL.
- [x] \`devtools::check(args = \"--as-cran\")\` -- 0 / 0 / 0.
- [x] \`devtools::spell_check()\` -- only pre-existing flags.
- [x] \`devtools::build_readme()\` -- builds without error (was
      failing on the V.PhyloMaker3 install step before this fix).
- [ ] @mlagisz to verify the README rewrite addresses her #53
      checklist items.
- [ ] V.PhyloMaker3 hotfix is self-merge -- I verified the repo
      doesn't exist via gh api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)