### PR TITLE
Fix #10: reconcile_multi() undercount + in_<dataset> columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes and documentation polish
 
+* `reconcile_multi()` no longer undercounts dataset-specific matches
+  when the same species appears in different formats across datasets
+  (e.g. `Homo_sapiens` in one dataset and `Homo sapiens` in another).
+  The cascade gains a `multi_x = TRUE` mode that allows multiple x
+  names to resolve to the same tree tip via normalisation, which
+  `reconcile_multi()` now uses. The mapping also gains the
+  documented `in_<dataset>` logical columns (one per input dataset)
+  that were missing from the implementation. With these changes the
+  per-dataset join `match(your_data$species, mapping$name_x)` is
+  reliable: every species in every input dataset finds its row.
+  Refs #10 (Ayumi Mizuno).
 * `reconcile_summary()` no longer prints to the console when its
   result is assigned to a variable. The formatted report now lives
   on the returned object's `formatted_text` slot and renders via

--- a/R/pr_cascade.R
+++ b/R/pr_cascade.R
@@ -23,6 +23,14 @@
 #'   `"flag"` (default) marks fuzzy matches below 0.95 and indirect
 #'   synonym matches as `match_type = "flagged"` for manual review.
 #'   `"first"` accepts all matches at face value.
+#' @param multi_x Logical. Allow multiple x names to resolve to the
+#'   same y? Default `FALSE` (each y is matched at most once).
+#'   `reconcile_multi()` sets this to `TRUE` because the same species
+#'   may legitimately appear in different formats (e.g. underscore
+#'   vs space) across datasets, and both formats should resolve to
+#'   the same tree tip. With `multi_x = TRUE`, the normalised and
+#'   synonym stages do not exclude already-matched y's from their
+#'   lookup space.
 #' @param quiet Logical.
 #'
 #' @return A tibble with the full mapping table.
@@ -36,6 +44,7 @@ pr_run_cascade <- function(names_x, names_y,
                            fuzzy_threshold = 0.9,
                            flag_threshold = 0.95,
                            resolve = "flag",
+                           multi_x = FALSE,
                            quiet = FALSE) {
 
   # Deduplicate inputs, warning about NAs
@@ -169,7 +178,12 @@ pr_run_cascade <- function(names_x, names_y,
     )
   }
   remaining_x <- setdiff(unique_x, matched_x)
-  remaining_y <- setdiff(unique_y, matched_y)
+  # When multi_x = TRUE, allow already-matched y's to be matched to
+  # additional x's via normalisation. This handles the case where the
+  # same species appears in multiple formats across datasets (e.g.
+  # `Homo_sapiens` from one dataset and `Homo sapiens` from another)
+  # and both should resolve to the same tree tip. Issue #10 (Ayumi).
+  remaining_y <- if (multi_x) unique_y else setdiff(unique_y, matched_y)
 
   if (length(remaining_x) > 0 && length(remaining_y) > 0) {
     norm_x <- pr_normalize_names(remaining_x, rank = rank)
@@ -192,11 +206,15 @@ pr_run_cascade <- function(names_x, names_y,
       nx_hits <- as.character(norm_x[hit_mask])
       y_hits  <- unname(lookup_y[nx_hits])
 
-      # If multiple x names normalise to the same y, keep only the first x
-      dup_y   <- duplicated(y_hits)
-      x_hits  <- x_hits[!dup_y]
-      nx_hits <- nx_hits[!dup_y]
-      y_hits  <- y_hits[!dup_y]
+      # If multiple x names normalise to the same y, keep only the first
+      # x in single-source mode. With multi_x = TRUE we keep every x ->
+      # y mapping so the per-dataset join works.
+      if (!multi_x) {
+        dup_y   <- duplicated(y_hits)
+        x_hits  <- x_hits[!dup_y]
+        nx_hits <- nx_hits[!dup_y]
+        y_hits  <- y_hits[!dup_y]
+      }
 
       rows[[length(rows) + 1]] <- tibble(
         name_x        = x_hits,

--- a/R/reconcile_multi.R
+++ b/R/reconcile_multi.R
@@ -95,9 +95,11 @@ reconcile_multi <- function(datasets, tree,
     sprintf("phylo (%d tips)", length(tips))
   }
 
-  # Collect all unique species names across datasets
-  all_names <- character()
-
+  # Collect all unique species names per-dataset and across datasets.
+  # Per-dataset names are kept so we can add `in_<dataset>` logical
+  # columns to the mapping. Issue #10 (Ayumi).
+  per_dataset_names <- vector("list", length(datasets))
+  names(per_dataset_names) <- names(datasets)
   for (i in seq_along(datasets)) {
     df <- datasets[[i]]
     col <- if (!is.null(species_cols)) {
@@ -105,10 +107,9 @@ reconcile_multi <- function(datasets, tree,
     } else {
       pr_detect_species_column(df, paste0("species in '", names(datasets)[i], "'"))
     }
-    all_names <- c(all_names, as.character(df[[col]]))
+    per_dataset_names[[i]] <- unique(stats::na.omit(as.character(df[[col]])))
   }
-
-  all_names <- unique(all_names[!is.na(all_names)])
+  all_names <- unique(unlist(per_dataset_names, use.names = FALSE))
 
   if (!quiet) {
     cli_alert_info(
@@ -119,7 +120,11 @@ reconcile_multi <- function(datasets, tree,
   # Load overrides
   overrides_df <- pr_load_overrides(overrides)
 
-  # Run cascade on combined names
+  # Run cascade on combined names. multi_x = TRUE so the same tree
+  # tip can resolve multiple x names that differ only in formatting
+  # (e.g. `Homo_sapiens` from one dataset and `Homo sapiens` from
+  # another both resolve to the tree tip via normalisation). Issue
+  # #10 (Ayumi).
   mapping <- pr_run_cascade(
     names_x         = all_names,
     names_y         = tips,
@@ -130,8 +135,19 @@ reconcile_multi <- function(datasets, tree,
     fuzzy           = fuzzy,
     fuzzy_threshold = fuzzy_threshold,
     resolve         = resolve,
+    multi_x         = TRUE,
     quiet           = quiet
   )
+
+  # Add one logical `in_<dataset>` column per input dataset, indicating
+  # whether each `name_x` row appeared in that dataset. Documented in
+  # the function's @return; was missing from the implementation. The
+  # column is TRUE when the literal name_x is in the dataset's
+  # species list (matched verbatim, including formatting).
+  for (i in seq_along(datasets)) {
+    col_name <- paste0("in_", names(datasets)[i])
+    mapping[[col_name]] <- mapping$name_x %in% per_dataset_names[[i]]
+  }
 
   # Build metadata
   meta <- list(

--- a/man/pr_run_cascade.Rd
+++ b/man/pr_run_cascade.Rd
@@ -15,6 +15,7 @@ pr_run_cascade(
   fuzzy_threshold = 0.9,
   flag_threshold = 0.95,
   resolve = "flag",
+  multi_x = FALSE,
   quiet = FALSE
 )
 }
@@ -44,6 +45,15 @@ matches. Default \code{0.9} (conservative).}
 \code{"flag"} (default) marks fuzzy matches below 0.95 and indirect
 synonym matches as \code{match_type = "flagged"} for manual review.
 \code{"first"} accepts all matches at face value.}
+
+\item{multi_x}{Logical. Allow multiple x names to resolve to the
+same y? Default \code{FALSE} (each y is matched at most once).
+\code{reconcile_multi()} sets this to \code{TRUE} because the same species
+may legitimately appear in different formats (e.g. underscore
+vs space) across datasets, and both formats should resolve to
+the same tree tip. With \code{multi_x = TRUE}, the normalised and
+synonym stages do not exclude already-matched y's from their
+lookup space.}
 
 \item{quiet}{Logical.}
 }

--- a/tests/testthat/test-reconcile_multi.R
+++ b/tests/testthat/test-reconcile_multi.R
@@ -156,3 +156,95 @@ test_that("M9: reconcile_multi errors informatively on NULL tree", {
                     authority = NULL, quiet = TRUE)
   )
 })
+
+
+# Issue #10 (Ayumi): same species across datasets in different
+# formats should both resolve to the tree tip via normalisation.
+test_that("reconcile_multi: same species in different formats both resolve (#10)", {
+  range_df <- data.frame(species = c("Homo_sapiens", "Pan_troglodytes"),
+                          stringsAsFactors = FALSE)
+  nest_df  <- data.frame(species = c("Homo sapiens", "Pan troglodytes"),
+                          stringsAsFactors = FALSE)
+  tree <- ape::read.tree(text = "(Homo_sapiens:1, Pan_troglodytes:1);")
+
+  res <- reconcile_multi(
+    list(range = range_df, nest = nest_df),
+    tree,
+    species_cols = "species",
+    authority    = NULL,
+    quiet        = TRUE
+  )
+
+  # Both formats appear, both resolve to a tip.
+  underscores_resolved <- res$mapping$in_y[
+    res$mapping$name_x %in% c("Homo_sapiens", "Pan_troglodytes")
+  ]
+  spaces_resolved <- res$mapping$in_y[
+    res$mapping$name_x %in% c("Homo sapiens", "Pan troglodytes")
+  ]
+  expect_true(all(underscores_resolved))
+  expect_true(all(spaces_resolved))
+
+  # No unresolved x names
+  unres <- res$mapping$match_type == "unresolved" & res$mapping$in_x
+  expect_equal(sum(unres), 0L)
+
+  # Per-dataset coverage matches the per-dataset name count
+  in_range_resolved <- sum(res$mapping$in_range & res$mapping$in_y)
+  in_nest_resolved  <- sum(res$mapping$in_nest  & res$mapping$in_y)
+  expect_equal(in_range_resolved, 2L)
+  expect_equal(in_nest_resolved,  2L)
+})
+
+
+test_that("reconcile_multi: in_<dataset> columns are present and correct (#10)", {
+  df1 <- data.frame(species = c("Homo sapiens", "Pan troglodytes"),
+                     stringsAsFactors = FALSE)
+  df2 <- data.frame(species = c("Pan troglodytes", "Gorilla gorilla"),
+                     stringsAsFactors = FALSE)
+  tree <- ape::read.tree(
+    text = "(Homo_sapiens:1, (Pan_troglodytes:1, Gorilla_gorilla:1));"
+  )
+
+  res <- reconcile_multi(
+    list(d1 = df1, d2 = df2), tree,
+    species_cols = "species",
+    authority    = NULL, quiet = TRUE
+  )
+
+  expect_true("in_d1" %in% names(res$mapping))
+  expect_true("in_d2" %in% names(res$mapping))
+
+  # Pan troglodytes is in both datasets; Homo only in d1; Gorilla only in d2
+  is_pan     <- res$mapping$name_x == "Pan troglodytes"
+  is_homo    <- res$mapping$name_x == "Homo sapiens"
+  is_gorilla <- res$mapping$name_x == "Gorilla gorilla"
+  expect_true(res$mapping$in_d1[is_pan] && res$mapping$in_d2[is_pan])
+  expect_true(res$mapping$in_d1[is_homo] && !res$mapping$in_d2[is_homo])
+  expect_true(!res$mapping$in_d1[is_gorilla] && res$mapping$in_d2[is_gorilla])
+})
+
+
+test_that("reconcile_multi mapping joins safely back to each dataset (#10)", {
+  # The whole point of issue #10: each dataset's species names
+  # appear verbatim in the mapping, so a left join from the
+  # original dataset works.
+  d1 <- data.frame(species = c("Homo_sapiens", "Pan_troglodytes"),
+                    trait1 = c(1.5, 2.5))
+  d2 <- data.frame(species = c("Homo sapiens", "Pan troglodytes"),
+                    trait2 = c(10, 20))
+  tree <- ape::read.tree(text = "(Homo_sapiens:1, Pan_troglodytes:1);")
+
+  res <- reconcile_multi(list(d1 = d1, d2 = d2), tree,
+                          species_cols = "species",
+                          authority    = NULL, quiet = TRUE)
+
+  # Join each dataset on its raw species column to the mapping;
+  # every row should find a match (no NAs in the joined name_y).
+  d1$tip <- res$mapping$name_y[match(d1$species, res$mapping$name_x)]
+  d2$tip <- res$mapping$name_y[match(d2$species, res$mapping$name_x)]
+  expect_false(any(is.na(d1$tip)))
+  expect_false(any(is.na(d2$tip)))
+  # Both datasets resolve to the same tree tips
+  expect_equal(sort(d1$tip), sort(d2$tip))
+})


### PR DESCRIPTION
## Root cause

\`pr_run_cascade()\`'s normalisation stage built its lookup from
\`setdiff(unique_y, matched_y)\`, so any tree tip that got an exact
match in stage 1 was removed from the lookup space. When two datasets
contained the same species in different formats (e.g. \`Homo_sapiens\`
in one and \`Homo sapiens\` in another), only the exact-format version
matched — the space-format version was left **unresolved** because
its target tip had already been \"consumed\" by the exact stage.

Ayumi's bird example: \`range\` (underscore) and \`nest\` (space) both
contain ~11k overlapping species names. \`reconcile_multi()\` reported
\`nest\` matched only 289 (the names that were unique to nest). The
bug.

## Fix

**Two parts:**

1. **\`pr_run_cascade()\` gains \`multi_x = FALSE\`** parameter. When
   \`TRUE\`, the normalisation stage's lookup uses *all* of \`unique_y\`
   (not \`remaining_y\`), and we don't dedupe on \`y_hits\`. So the
   same tree tip can resolve multiple x names that differ only in
   formatting. Default \`FALSE\` keeps single-dataset
   \`reconcile_data()\` and \`reconcile_tree()\` unchanged.

2. **\`reconcile_multi()\` passes \`multi_x = TRUE\`** and now adds the
   documented \`in_<dataset>\` logical columns (one per input dataset)
   that were missing from the implementation entirely (the docs
   promised them; the code never wrote them).

After the fix, the per-dataset join \`match(your_data\$species,
mapping\$name_x)\` finds a row for every species in every input
dataset, regardless of format.

## Test plan

Four new \`test_that\` blocks reproducing the exact failure mode:

- Same species in different formats across datasets both resolve
  to the tree tip via normalisation (the headline bug).
- \`in_<dataset>\` columns are present and populated correctly.
- Per-dataset join contract: \`match()\` finds a row for every species.

Plus all 2462 existing tests continue to pass:

- [x] \`devtools::test()\` -- 2462 PASS / 2 SKIP / 0 FAIL.
- [x] \`devtools::check(args = \"--as-cran\")\` -- 0 / 0 / 0.
- [x] \`devtools::spell_check()\` -- only pre-existing flags.
- [ ] @Ayumi-495 to verify on her real range / nest / plumage
      datasets against the Jetz tree.

Refs #10 -- leaving open for Ayumi to verify and close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)