### PR TITLE
Sort CI red badges: trim workflow + move datelife to Enhances

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,11 +68,14 @@ jobs:
           # backends for the augment / retrieval functions
           # (eliotmiller/clootl, daijiang/rtrees,
           # jinyizju/V.PhyloMaker(2|), jinyizju/U.PhyloMaker). Note:
-          # phylotastic/datelife is NOT in Remotes -- its transitive
-          # `bold` dep can't be resolved by pak on a clean CI image.
-          # Users who want the datelife backend install it manually
-          # following the runtime install hint.
+          # phylotastic/datelife lives in DESCRIPTION's `Enhances:`
+          # field (not Suggests / Remotes) -- its transitive `bold`
+          # dep can't be resolved by pak on a clean CI image.
+          # `dependencies` below explicitly excludes Enhances so pak
+          # doesn't try. Users who want the datelife backend install
+          # it manually following the runtime install hint.
           extra-packages: any::rcmdcheck
+          dependencies: '"Imports", "Depends", "LinkingTo", "Suggests"'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,8 +1,32 @@
+# Local checks (devtools::check, devtools::test) are the source of
+# truth for this package. CI is intentionally lean:
+#
+#   * Triggered only on pull_request and on workflow_dispatch (manual
+#     trigger via the GitHub UI). Skipped on push to main, where the
+#     pre-merge PR run already covered it.
+#   * Runs Linux-only by default (cheap, fast). The cross-OS matrix
+#     (macOS + Windows) is enabled by adding the `os: full` input to a
+#     workflow_dispatch run -- use it before a release / CRAN
+#     submission, not on every PR.
+#
+# Background: GitHub Actions minutes cost real money on macOS / Windows
+# runners. Local Mac runs the same checks instantly; the team-level
+# CLAUDE.md guidance is "local checks over GitHub Actions" precisely
+# for this reason.
+
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'OS matrix to run (default = ubuntu-only; "full" adds macOS + Windows)'
+        required: false
+        default: 'ubuntu'
+        type: choice
+        options:
+          - ubuntu
+          - full
 
 name: R-CMD-check
 
@@ -17,12 +41,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'oldrel-1'}
+        # Default: Linux release-only. Manual workflow_dispatch with
+        # os = "full" adds macOS + Windows.
+        config: ${{ fromJSON(github.event.inputs.os == 'full'
+          && '[{"os":"ubuntu-latest","r":"release"},{"os":"macos-latest","r":"release"},{"os":"windows-latest","r":"release"}]'
+          || '[{"os":"ubuntu-latest","r":"release"}]') }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -41,10 +64,14 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # The DESCRIPTION's `Remotes:` field points pak at
-          # `eliotmiller/clootl` and `daijiang/rtrees` (GitHub-only
-          # backends for `pr_get_tree()`), so they install correctly
-          # during dependency resolution.
+          # `Remotes:` in DESCRIPTION points pak at the GitHub-only
+          # backends for the augment / retrieval functions
+          # (eliotmiller/clootl, daijiang/rtrees,
+          # jinyizju/V.PhyloMaker(2|), jinyizju/U.PhyloMaker). Note:
+          # phylotastic/datelife is NOT in Remotes -- its transitive
+          # `bold` dep can't be resolved by pak on a clean CI image.
+          # Users who want the datelife backend install it manually
+          # following the runtime install hint.
           extra-packages: any::rcmdcheck
           needs: check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: prepR4pcm
 Title: Prepare Data and Trees for Phylogenetic Comparative Methods
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(
     person("Shinichi", "Nakagawa",
            email = "s.nakagawa@unsw.edu.au",
@@ -47,7 +47,6 @@ Imports:
 Suggests:
     caper,
     clootl,
-    datelife,
     digest,
     dplyr,
     fishtree,
@@ -66,15 +65,15 @@ Suggests:
     U.PhyloMaker,
     V.PhyloMaker,
     V.PhyloMaker2
+Enhances:
+    datelife
 Additional_repositories:
     https://eliotmiller.r-universe.dev,
     https://daijiang.r-universe.dev,
-    https://phylotastic.r-universe.dev,
     https://jinyizju.r-universe.dev
 Remotes:
     eliotmiller/clootl,
     daijiang/rtrees,
-    phylotastic/datelife,
     jinyizju/V.PhyloMaker2,
     jinyizju/V.PhyloMaker,
     jinyizju/U.PhyloMaker

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # prepR4pcm 0.4.0.9000 (development version)
 
+## CI cleanup
+
+* **CI workflow trimmed** to `pull_request` + `workflow_dispatch`
+  only (was: `push` + `pull_request`), Linux-only by default (was:
+  full macOS / Windows / Linux x 3 R-version matrix). The
+  `workflow_dispatch` trigger has an `os` input -- set it to `full`
+  before a release / CRAN submission to re-run the full matrix
+  manually. Saves GitHub Actions minutes (~85% reduction) and
+  matches the team's "local checks over CI" preference per
+  `CLAUDE.md`.
+* **`datelife` moved from `Suggests` + `Remotes` to `Enhances`**
+  in `DESCRIPTION`. Reason: datelife was archived from CRAN in
+  2024 and has a heavy transitive dep tree (`bold`, `phylobase`,
+  Bioconductor packages) that pak's resolver cannot install on
+  clean CI images. `Enhances` declares the relationship so R CMD
+  check is happy, but pak doesn't try to auto-install it. Users
+  who want the datelife backend run
+  `pak::pak("phylotastic/datelife")` themselves; the runtime
+  `requireNamespace("datelife")` guard in
+  `.pr_get_tree_datelife()` and `.pr_date_tree_datelife()`
+  produces a clear install hint when datelife is missing.
+* `\pkg{datelife}` references in roxygen replaced with
+  `\code{datelife}` to match the new dependency status.
+
 ## Bug fixes and documentation polish
 
 * `reconcile_multi()` no longer undercounts dataset-specific matches

--- a/R/pr_date_tree.R
+++ b/R/pr_date_tree.R
@@ -21,8 +21,13 @@
 #' Use `pr_date_tree()` when you already have a topology (e.g. from a
 #' published phylogeny or your own analysis) and want to attach
 #' divergence times. Use [pr_get_tree()] with `source = "datelife"` if
-#' you have only species names. Both end up calling \pkg{datelife},
-#' but the starting point is different.
+#' you have only species names. Both end up calling the GitHub-only
+#' \code{datelife} package, but the starting point is different.
+#' Install \code{datelife} before calling this function ---
+#' \pkg{prepR4pcm} does NOT pull it in via `Suggests` (its transitive
+#' dep tree can't be auto-resolved by pak on a clean CI image, so
+#' we keep it as an opt-in install):
+#' \code{pak::pak("phylotastic/datelife")}.
 #'
 #' @param tree An `ape::phylo` (or `multiPhylo`) object: the topology
 #'   to calibrate.

--- a/R/pr_get_tree.R
+++ b/R/pr_get_tree.R
@@ -65,13 +65,15 @@
 #'       results.}
 #'     \item{\code{"datelife"}}{Universal database of pre-computed
 #'       chronograms (Sanchez Reyes et al. 2024, *Syst. Biol.*
-#'       73:470), via the GitHub package \pkg{datelife}
+#'       73:470), via the GitHub package \code{datelife}
 #'       (\url{https://github.com/phylotastic/datelife}). Returns a
 #'       single SDM-summary chronogram by default; with
 #'       \code{n_tree > 1}, returns a multiPhylo of up to that many
-#'       per-source candidate chronograms. Install with
-#'       \code{pak::pak("phylotastic/datelife")} (the package was
-#'       archived from CRAN in 2024).}
+#'       per-source candidate chronograms. **Install before use**
+#'       with \code{pak::pak("phylotastic/datelife")} --- the package
+#'       is GitHub-only (archived from CRAN in 2024 with a heavy
+#'       transitive dep tree pak can't auto-resolve), so \pkg{prepR4pcm}
+#'       does NOT pull it in via `Suggests`.}
 #'     \item{\code{"auto"}}{Fall-through dispatcher: try installed
 #'       backends in priority order (rtrees if `taxon` provided,
 #'       then rotl, fishtree, clootl, datelife), return the first
@@ -145,7 +147,7 @@
 #'   \pkg{rotl}, \code{extractTree} in \pkg{clootl},
 #'   \code{get_tree} in \pkg{rtrees}, \code{fishtree_phylogeny} /
 #'   \code{fishtree_complete_phylogeny} in \pkg{fishtree},
-#'   \code{datelife_search} in \pkg{datelife}) for the full list.
+#'   \code{datelife_search} in \code{datelife}) for the full list.
 #'
 #' @return A list with class `pr_tree_result` and components:
 #' \describe{

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -224,3 +224,4 @@ TimeTree's
 PGLMMs
 R's
 REPL
+dep

--- a/man/pr_date_tree.Rd
+++ b/man/pr_date_tree.Rd
@@ -65,8 +65,13 @@ code.
 Use \code{pr_date_tree()} when you already have a topology (e.g. from a
 published phylogeny or your own analysis) and want to attach
 divergence times. Use \code{\link[=pr_get_tree]{pr_get_tree()}} with \code{source = "datelife"} if
-you have only species names. Both end up calling \pkg{datelife},
-but the starting point is different.
+you have only species names. Both end up calling the GitHub-only
+\code{datelife} package, but the starting point is different.
+Install \code{datelife} before calling this function ---
+\pkg{prepR4pcm} does NOT pull it in via \code{Suggests} (its transitive
+dep tree can't be auto-resolved by pak on a clean CI image, so
+we keep it as an opt-in install):
+\code{pak::pak("phylotastic/datelife")}.
 }
 
 \examples{

--- a/man/pr_get_tree.Rd
+++ b/man/pr_get_tree.Rd
@@ -57,13 +57,15 @@ with \code{\link[=reconcile_data]{reconcile_data()}} (with a \code{taxadb} autho
 results.}
 \item{\code{"datelife"}}{Universal database of pre-computed
 chronograms (Sanchez Reyes et al. 2024, \emph{Syst. Biol.}
-73:470), via the GitHub package \pkg{datelife}
+73:470), via the GitHub package \code{datelife}
 (\url{https://github.com/phylotastic/datelife}). Returns a
 single SDM-summary chronogram by default; with
 \code{n_tree > 1}, returns a multiPhylo of up to that many
-per-source candidate chronograms. Install with
-\code{pak::pak("phylotastic/datelife")} (the package was
-archived from CRAN in 2024).}
+per-source candidate chronograms. \strong{Install before use}
+with \code{pak::pak("phylotastic/datelife")} --- the package
+is GitHub-only (archived from CRAN in 2024 with a heavy
+transitive dep tree pak can't auto-resolve), so \pkg{prepR4pcm}
+does NOT pull it in via \code{Suggests}.}
 \item{\code{"auto"}}{Fall-through dispatcher: try installed
 backends in priority order (rtrees if \code{taxon} provided,
 then rotl, fishtree, clootl, datelife), return the first
@@ -145,7 +147,7 @@ relevant backend package (\code{tol_induced_subtree} in
 \pkg{rotl}, \code{extractTree} in \pkg{clootl},
 \code{get_tree} in \pkg{rtrees}, \code{fishtree_phylogeny} /
 \code{fishtree_complete_phylogeny} in \pkg{fishtree},
-\code{datelife_search} in \pkg{datelife}) for the full list.}
+\code{datelife_search} in \code{datelife}) for the full list.}
 }
 \value{
 A list with class \code{pr_tree_result} and components:


### PR DESCRIPTION
## Why

The 5/5 R-CMD-check failures across the OS x R-version matrix have all
had the same root cause: pak couldn't resolve
\`phylotastic/datelife\`'s transitive \`bold\` dep on a clean CI image.
We accepted this in Round 4-7 as a known issue tracked upstream at
[phylotastic/datelife#97](https://github.com/phylotastic/datelife/issues/97)
— but the red badge is noise on every PR.

This PR sorts the noise without losing real signal.

## What

**1. CI workflow trimmed** to match the team's \"local checks over
CI\" preference:

| | Before | After |
|---|---|---|
| Triggers | \`push\` to main + \`pull_request\` | \`pull_request\` + \`workflow_dispatch\` |
| Default matrix | macOS + Windows + ubuntu × 3 R versions | ubuntu-latest release-only |
| Cross-OS coverage | every PR | manual: \`workflow_dispatch\` with \`os: full\` |

Saves ~85% of GitHub Actions minutes. Cross-OS still available before
a release: trigger the workflow manually from the Actions tab with
\`os = full\`.

**2. \`datelife\` moved from \`Suggests\` + \`Remotes\` to \`Enhances\`**:
\`Enhances:\` declares the relationship without forcing pak to
install. R CMD check is happy; CI doesn't try to resolve \`bold\`.
Runtime \`requireNamespace(\"datelife\")\` guard unchanged — users
who want the backend run \`pak::pak(\"phylotastic/datelife\")\` and the
helper produces a clear install hint when not installed.

**3. \`\\pkg{datelife}\` → \`\\code{datelife}\` in roxygen** so R CMD
check doesn't warn about \`\\pkg{X}\` refs to undeclared deps.

## Test plan

- [x] \`devtools::test()\` — 2470 PASS / 2 SKIP / 0 FAIL.
- [x] \`devtools::check(args = \"--as-cran\")\` — 0 / 0 / 0.
- [x] \`devtools::spell_check()\` — only pre-existing flags.
- [ ] **The actual goal**: this PR's own R-CMD-check should be
      green when CI runs on the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)