### PR TITLE
CI: fix the dependencies syntax (must be valid R)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,7 +75,7 @@ jobs:
           # doesn't try. Users who want the datelife backend install
           # it manually following the runtime install hint.
           extra-packages: any::rcmdcheck
-          dependencies: '"Imports", "Depends", "LinkingTo", "Suggests"'
+          dependencies: 'c("Imports", "Depends", "LinkingTo", "Suggests")'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
PR #58 was merged at \`55e98ee\` before my follow-up commit
(\`9329a73\`) was applied. The merged version has the broken
\`dependencies: '\"Imports\", \"Depends\", \"LinkingTo\", \"Suggests\"'\`
which interpolates into invalid R syntax (\`dependencies = c(needs,
(\"Imports\",\"...\"))\` → \`unexpected ','\`).

This PR cherry-picks the one-character fix: wrap with \`c(...)\` so
the action's R interpolation produces valid syntax:

\`dependencies: 'c(\"Imports\", \"Depends\", \"LinkingTo\", \"Suggests\")'\`

Same intent, runs.