### PR TITLE
fix(authority): do not forward version=NULL to taxadb (#83)

### DIFF
--- a/R/pr_authority.R
+++ b/R/pr_authority.R
@@ -199,13 +199,15 @@ pr_lookup_authority <- function(names, authority = "col", db_version = NULL) {
   }
 
   if (length(to_lookup) > 0) {
-    # Batch query: taxadb::filter_name accepts a character vector
+    # Batch query: taxadb::filter_name accepts a character vector.
+    # Only forward `version` when the caller supplied one — taxadb 0.2.1
+    # errors on `version = NULL` because parse_schema() runs
+    # `if (version == "latest")` and gets logical(0). Omitting the
+    # argument lets taxadb fall back to latest_version().
+    filter_args <- list(to_lookup, provider = authority)
+    if (!is.null(db_version)) filter_args$version <- db_version
     all_hits <- tryCatch(
-      taxadb::filter_name(
-        to_lookup,
-        provider = authority,
-        version = db_version
-      ),
+      do.call(taxadb::filter_name, filter_args),
       error = function(e) {
         cli_alert_warning(
           "taxadb lookup failed for {.val {authority}}: {conditionMessage(e)}. Names will be recorded as not found."
@@ -226,13 +228,16 @@ pr_lookup_authority <- function(names, authority = "col", db_version = NULL) {
         ))
       }
 
-      hits <- all_hits[all_hits$scientificName == name |
-                         all_hits$input == name, , drop = FALSE]
-
-      # taxadb may use an 'input' column to match query names
-      if (nrow(hits) == 0 && "input" %in% names(all_hits)) {
-        hits <- all_hits[all_hits$input == name, , drop = FALSE]
+      # Match on scientificName, and on `input` only if taxadb provides
+      # that column. taxadb 0.2.1 returns scientificName but not input,
+      # so unconditionally referencing all_hits$input returns NULL and
+      # `NULL == name` yields logical(0), which then collides with the
+      # length-N scientificName mask under tibble's strict subscripting.
+      match_mask <- all_hits$scientificName == name
+      if ("input" %in% names(all_hits)) {
+        match_mask <- match_mask | all_hits$input == name
       }
+      hits <- all_hits[match_mask, , drop = FALSE]
 
       if (nrow(hits) == 0) {
         return(tibble(
@@ -263,11 +268,9 @@ pr_lookup_authority <- function(names, authority = "col", db_version = NULL) {
 
       if (!is.na(accepted_id) && nchar(accepted_id) > 0) {
         tryCatch({
-          accepted_hit <- taxadb::filter_id(
-            accepted_id,
-            provider = authority,
-            version = db_version
-          )
+          id_args <- list(accepted_id, provider = authority)
+          if (!is.null(db_version)) id_args$version <- db_version
+          accepted_hit <- do.call(taxadb::filter_id, id_args)
           if (!is.null(accepted_hit) && nrow(accepted_hit) > 0) {
             return(tibble(
               input         = name,

--- a/tests/testthat/test-pr_lookup_authority-version.R
+++ b/tests/testthat/test-pr_lookup_authority-version.R
@@ -1,0 +1,115 @@
+# Regression tests for #83: with the default db_version = NULL,
+# pr_lookup_authority used to forward version = NULL to taxadb::filter_name.
+# taxadb 0.2.1's parse_schema() then ran `if (version == "latest")` and
+# errored with logical(0), producing
+#   "no match found for schema: dwc provider: col version:"
+# Fix: only include the `version` argument when the caller supplied one.
+
+test_that("filter_name receives no version arg when db_version = NULL (#83)", {
+  skip_if_not_installed("taxadb")
+
+  captured <- NULL
+  fake_filter_name <- function(...) {
+    captured <<- list(...)
+    tibble::tibble(
+      scientificName       = "Salmo salar",
+      taxonomicStatus      = "accepted",
+      taxonID              = "COL:1",
+      acceptedNameUsageID  = "COL:1"
+    )
+  }
+
+  testthat::local_mocked_bindings(
+    filter_name = fake_filter_name,
+    .package    = "taxadb"
+  )
+  testthat::local_mocked_bindings(
+    pr_ensure_db = function(authority, db_version = NULL) invisible(authority),
+    .package     = "prepR4pcm"
+  )
+
+  res <- pr_lookup_authority(
+    c("Salmo salar"),
+    authority  = "col",
+    db_version = NULL
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_false(
+    "version" %in% names(captured),
+    info = paste0(
+      "When db_version is NULL, pr_lookup_authority must NOT forward ",
+      "version = NULL to taxadb::filter_name (taxadb 0.2.1 crashes ",
+      "inside parse_schema)."
+    )
+  )
+})
+
+test_that("filter_name receives the explicit version when db_version is set", {
+  skip_if_not_installed("taxadb")
+
+  captured <- NULL
+  fake_filter_name <- function(...) {
+    captured <<- list(...)
+    tibble::tibble(
+      scientificName       = "Salmo salar",
+      taxonomicStatus      = "accepted",
+      taxonID              = "COL:1",
+      acceptedNameUsageID  = "COL:1"
+    )
+  }
+
+  testthat::local_mocked_bindings(
+    filter_name = fake_filter_name,
+    .package    = "taxadb"
+  )
+  testthat::local_mocked_bindings(
+    pr_ensure_db = function(authority, db_version = NULL) invisible(authority),
+    .package     = "prepR4pcm"
+  )
+
+  pr_lookup_authority(
+    c("Salmo salar"),
+    authority  = "col",
+    db_version = "22.12"
+  )
+
+  expect_equal(captured$version, "22.12")
+})
+
+test_that("scientificName-only taxadb output does not crash subscripting (#83)", {
+  skip_if_not_installed("taxadb")
+
+  # Real taxadb 0.2.1 returns filter_name output WITHOUT an `input`
+  # column. The previous code did
+  #   all_hits$scientificName == name | all_hits$input == name
+  # which evaluates the RHS to `NULL == name` -> logical(0). Tibble
+  # then complained: "Unknown or uninitialised column: `input`".
+  fake_filter_name <- function(...) {
+    tibble::tibble(
+      scientificName       = c("Salmo salar", "Esox lucius"),
+      taxonomicStatus      = c("accepted", "accepted"),
+      taxonID              = c("COL:1", "COL:2"),
+      acceptedNameUsageID  = c("COL:1", "COL:2")
+    )
+  }
+
+  testthat::local_mocked_bindings(
+    filter_name = fake_filter_name,
+    .package    = "taxadb"
+  )
+  testthat::local_mocked_bindings(
+    pr_ensure_db = function(authority, db_version = NULL) invisible(authority),
+    .package     = "prepR4pcm"
+  )
+
+  expect_warning(
+    res <- pr_lookup_authority(
+      c("Salmo salar", "Esox lucius"),
+      authority = "col"
+    ),
+    regexp = NA  # no warning expected
+  )
+  expect_equal(nrow(res), 2)
+  expect_equal(res$status, c("accepted", "accepted"))
+})


### PR DESCRIPTION
Closes the bug reported in #83 by **cossee-ualberta** — `reconcile_tree(authority = \"col\")` failing with `taxadb lookup failed ... no match found for schema: dwc provider: col version: .`.

## Diagnosis

Root cause: `pr_lookup_authority()` always forwarded its `db_version` argument to `taxadb::filter_name()` / `taxadb::filter_id()`, even when the caller did not supply one. The default is `NULL`. taxadb 0.2.1's internal `parse_schema()` runs:

\`\`\`r
if (version == \"latest\") version <- max(versions)
\`\`\`

With `version = NULL`, that comparison returns `logical(0)` → the `if` errors → taxadb's catch-all wraps it as `\"no match found for schema: dwc provider: col version:\"`. The intent was \"NULL means use taxadb's default `latest_version()`,\" but **explicitly passing `version = NULL`** defeats the default.

Reproduced in isolation:
\`\`\`r
taxadb::filter_name(\"Salmo salar\", provider = \"col\", version = NULL)
#> Error: no match found for schema: dwc provider: col version:
\`\`\`

Versus the working form (which is what taxadb expects):
\`\`\`r
taxadb::filter_name(\"Salmo salar\", provider = \"col\")
#> tibble: 1 x 25 (works)
\`\`\`

## Fix

Build the argument list and only set `version` when `db_version` is non-`NULL`, so taxadb's own default `latest_version()` takes over.

\`\`\`r
filter_args <- list(to_lookup, provider = authority)
if (!is.null(db_version)) filter_args\$version <- db_version
all_hits <- tryCatch(do.call(taxadb::filter_name, filter_args), ...)
\`\`\`

Same pattern applied to the `filter_id()` call that follows synonyms to their accepted name.

## Second bug surfaced after the first was fixed

The per-name dispatcher then crashed at:

\`\`\`r
hits <- all_hits[all_hits\$scientificName == name |
                   all_hits\$input == name, , drop = FALSE]
\`\`\`

taxadb 0.2.1's `filter_name()` returns no `input` column, so `all_hits\$input` is `NULL`, `NULL == name` is `logical(0)`, and under tibble's strict subscripting this raised:

\`\`\`
Unknown or uninitialised column: \`input\`.
Error: Can't subset rows with \`...\`
\`\`\`

Fixed by only mixing in the `input` mask when the column exists.

## Regression tests

Adds `tests/testthat/test-pr_lookup_authority-version.R` (6 tests) covering:

1. `filter_name` receives **no** `version` argument when `db_version = NULL` (regression test for #83).
2. `filter_name` receives the **explicit** `version` when `db_version` is set.
3. scientificName-only taxadb output (no `input` column) does not crash subscripting.

Existing tests pass:
- `test-authority-mocked.R` ✓ (29 tests)
- `test-authority-error-messages.R` ✓ (17 tests + 1 expected skip)
- `test-claim-authority-parity.R` ✓ (off-CRAN only)

## Verification

\`\`\`r
devtools::load_all()
data(avonet_subset); data(tree_jetz)
rec <- reconcile_tree(avonet_subset, tree_jetz, x_species = \"Species1\", authority = \"col\")
# ℹ Stage 3/3: Synonym resolution (657 matched so far)...
# ✔ Matched 657/919 data names to tree tips
\`\`\`

No more lookup failure.

## Test plan

- [x] Mocked tests pass locally
- [x] End-to-end `reconcile_tree(..., authority = \"col\")` runs cleanly
- [ ] Reporter (Bhavya) confirms the original AVONET-vs-tree call now works
- [ ] CI R-CMD-check passes

Refs #83. **Does not close the issue** — let the reporter verify and close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)