### PR TITLE
docs(vignettes): address @mlagisz feedback on #89 and #90

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     knitr,
     MCMCglmm,
     phytools,
+    piggyback,
     pkgdown,
     readr,
     rmarkdown,

--- a/docs/articles/comparing-tree-backends.html
+++ b/docs/articles/comparing-tree-backends.html
@@ -25,7 +25,7 @@
 
     <a class="navbar-brand me-2" href="../index.html">prepR4pcm</a>
 
-    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Released version">0.4.0.9000</small>
+    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">0.4.0.9000</small>
 
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -85,10 +85,39 @@ have given.</p>
 <div class="section level2">
 <h2 id="setup">Setup<a class="anchor" aria-label="anchor" href="#setup"></a>
 </h2>
+<p>Comparison requires multiple tree-retrieval backends installed. Each
+backend lives in a different package because each draws on a different
+reference tree or taxonomy:</p>
+<ul>
+<li>
+<strong><code>rotl</code></strong> (CRAN): client for the Open Tree
+of Life synthesis tree — the only backend with universal taxon coverage.
+Required for <code>source = "rotl"</code>.</li>
+<li>
+<strong><code>fishtree</code></strong> (CRAN): wraps the Rabosky et
+al. (2018) time-calibrated ray-finned fish phylogeny. Required for
+<code>source = "fishtree"</code>.</li>
+<li>
+<strong><code>rtrees</code></strong> (GitHub only): grafts species
+onto taxon-specific mega-trees (mammals, birds, fish, amphibians, etc.).
+Required for <code>source = "rtrees"</code>.</li>
+<li>
+<strong><code>clootl</code></strong> (GitHub only): supplies the
+Clements bird-taxonomy phylogeny. Required for
+<code>source = "clootl"</code>.</li>
+<li>
+<strong><code>datelife</code></strong> (GitHub only): synthesis
+chronograms from many per-clade published trees. Required for
+<code>source = "datelife"</code>.</li>
+</ul>
+<p>Install whichever you need. CRAN packages first, then GitHub-only
+backends via <code>pak</code>:</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/itchyshin/prepR4pcm" class="external-link">prepR4pcm</a></span><span class="op">)</span></span>
-<span><span class="co"># install.packages(c("rotl", "fishtree"))</span></span>
-<span><span class="co"># pak::pak(c("eliotmiller/clootl", "daijiang/rtrees", "phylotastic/datelife"))</span></span></code></pre></div>
+<span><span class="co"># install.packages(c("rotl", "fishtree"))                 # CRAN</span></span>
+<span><span class="co"># pak::pak("daijiang/rtrees")                             # GitHub</span></span>
+<span><span class="co"># pak::pak("eliotmiller/clootl")                          # GitHub</span></span>
+<span><span class="co"># pak::pak("phylotastic/datelife")                        # GitHub (heavy)</span></span></code></pre></div>
 <p>Check what’s installed and reachable in your session:</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="fu"><a href="../reference/pr_get_tree_status.html">pr_get_tree_status</a></span><span class="op">(</span><span class="op">)</span></span>
@@ -118,6 +147,16 @@ backends. Compare.</p>
 <span><span class="va">res_rotl</span>     <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"rotl"</span><span class="op">)</span></span>
 <span><span class="va">res_fishtree</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"fishtree"</span><span class="op">)</span></span>
 <span><span class="va">res_rtrees</span>   <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"rtrees"</span>, taxon <span class="op">=</span> <span class="st">"fish"</span><span class="op">)</span></span></code></pre></div>
+<p><strong>About the <code>TNRS replaced ...</code> warning.</strong>
+<code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> runs the Open Tree of Life Taxonomic Name
+Resolution Service (TNRS) on the input names before passing them to the
+backend, so that minor spelling or capitalisation differences don’t
+cause a name to fall out of the tree silently. When TNRS finds a
+canonical form that differs from the input (e.g. an old binomial
+replaced by the current synonym), the wrapper substitutes the canonical
+form and emits a warning listing each replacement, so the substitution
+is visible in the run log. The retrieval still succeeds; the warning is
+informational.</p>
 <p>The three results are independent. Now compare:</p>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">cmp</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_tree_compare.html">pr_tree_compare</a></span><span class="op">(</span></span>
@@ -126,27 +165,58 @@ backends. Compare.</p>
 <span>  rtrees   <span class="op">=</span> <span class="va">res_rtrees</span></span>
 <span><span class="op">)</span></span>
 <span><span class="va">cmp</span></span></code></pre></div>
-<p>The print method shows three pairwise matrices. Reading them:</p>
+<p>The print method shows up to three pairwise matrices, depending on
+what is computable for your set of trees. Reading them:</p>
 <ul>
 <li>
 <strong>Tip-set Jaccard</strong> — fraction of species both trees
 place. 1.0 = same species set. 0.0 = no overlap. If any pairwise value
-is &lt; 1, you’re not comparing apples to apples.</li>
+is &lt; 1, the two trees do not cover the same species set, so the
+topological comparison below is restricted to the species both trees
+include.</li>
 <li>
 <strong>Robinson-Foulds distance</strong> — number of internal edges
 that differ between the two trees, restricted to their shared tip set.
-Lower = trees agree more.</li>
+Lower = trees agree more. <strong><code>NA</code> off-diagonal</strong>
+means the shared-tip subtree has fewer than four taxa (Robinson-Foulds
+is undefined below four shared tips), or one of the input trees could
+not be pruned to the shared subtree without becoming degenerate.
+Diagonal values are always 0 (a tree against itself).</li>
 <li>
 <strong>Branch-length correlation</strong> — Pearson correlation of
 sorted edge lengths after pruning to the shared subtree. Useful as a
-rough check on whether two chronograms agree on rate scale.</li>
+rough check on whether two chronograms use the same branch-length scale
+(e.g. millions of years vs unit-length placeholders). <strong>This
+matrix is only printed when at least one pair has computable branch
+lengths on both sides.</strong> If <code>rotl</code> trees (which carry
+unit-length placeholder branches) are part of the comparison, the matrix
+may collapse to NA and the print method drops it; that is why you
+sometimes see only two matrices rather than three.</li>
 </ul>
 </div>
 <div class="section level2">
 <h2 id="what-actually-works-status-table">What actually works (status table)<a class="anchor" aria-label="anchor" href="#what-actually-works-status-table"></a>
 </h2>
 <p>Backends differ in coverage and in what <code>n_tree &gt; 1</code>
-does. Verified on a clean macOS R 4.4 install on 2026-05-01:</p>
+does. Verified on a clean macOS R 4.4 install on 2026-05-01. Column
+meanings:</p>
+<ul>
+<li>
+<strong>Backend</strong> — the value you pass as
+<code>source = "..."</code> to <code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code>.</li>
+<li>
+<strong>Single tree</strong> — does
+<code>pr_get_tree(..., n_tree = 1)</code> (the default) return a single
+<code><a href="https://rdrr.io/pkg/ape/man/read.tree.html" class="external-link">ape::phylo</a></code> object cleanly?</li>
+<li>
+<strong>Multi-tree (<code>n_tree &gt; 1</code>)</strong> — does the
+backend support returning a posterior or sample of trees? Some backends
+ship a single mega-tree and ignore <code>n_tree</code>; others support a
+true posterior sample.</li>
+<li>
+<strong>Notes</strong> — backend-specific gotchas worth knowing
+before you trust the result.</li>
+</ul>
 <table class="table">
 <colgroup>
 <col width="25%">
@@ -244,14 +314,45 @@ sufficient for the great majority of phylogenetic comparative
 analyses.</p>
 </div>
 <div class="section level2">
+<h2 id="note-on-tip-labels-before-comparing">Note on tip labels before comparing<a class="anchor" aria-label="anchor" href="#note-on-tip-labels-before-comparing"></a>
+</h2>
+<p>The three backends use different conventions for tip labels:</p>
+<ul>
+<li>
+<strong><code>rotl</code></strong> appends an Open Tree OTT id to
+each tip (e.g. <code>Salmo_salar_ott854188</code>) and lower-cases the
+binomial.</li>
+<li>
+<strong><code>fishtree</code></strong> returns the canonical
+binomial with spaces (<code>Salmo salar</code>).</li>
+<li>
+<strong><code>rtrees</code></strong> returns the canonical binomial
+with underscores (<code>Salmo_salar</code>).</li>
+</ul>
+<p><code><a href="../reference/pr_tree_compare.html">pr_tree_compare()</a></code> matches tips by <strong>case- and
+separator-folded binomial</strong> (it strips
+<code>_ott&lt;digits&gt;</code>, converts underscores to spaces, and
+lower-cases) before computing Jaccard, so you do not need to clean the
+labels yourself for the comparison to work. The folded form is used only
+for matching; the original tip labels are preserved in each tree.</p>
+<p>If you intend to use one of the returned trees downstream (e.g. feed
+it to <code><a href="../reference/pr_phylo_cor.html">pr_phylo_cor()</a></code> and then to
+<code><a href="https://wviechtb.github.io/metafor/reference/rma.mv.html" class="external-link">metafor::rma.mv()</a></code>), you will usually want to strip those
+suffixes yourself with <code>gsub("_ott\\d+", "", tree$tip.label)</code>
+first. See the <em>meta-analysis-with-rotl</em> vignette for that
+workflow.</p>
+</div>
+<div class="section level2">
 <h2 id="what-to-do-with-the-result">What to do with the result<a class="anchor" aria-label="anchor" href="#what-to-do-with-the-result"></a>
 </h2>
 <div class="section level3">
-<h3 id="when-all-three-agree-jaccard-1-rf-small">When all three agree (Jaccard ≈ 1, RF small)<a class="anchor" aria-label="anchor" href="#when-all-three-agree-jaccard-1-rf-small"></a>
+<h3 id="when-the-backends-return-the-same-species-set-and-similar-topology-jaccard-1-rf-small">When the backends return the same species set and similar topology
+(Jaccard ≈ 1, RF small)<a class="anchor" aria-label="anchor" href="#when-the-backends-return-the-same-species-set-and-similar-topology-jaccard-1-rf-small"></a>
 </h3>
-<p>Great. Use whichever backend best matches your taxonomic / temporal
-needs. Document the choice. Call <code><a href="../reference/pr_cite_tree.html">pr_cite_tree()</a></code> to capture
-the citation:</p>
+<p>The backends return the same species set (Jaccard ≈ 1) and broadly
+similar topologies (low Robinson-Foulds distance). Pick whichever
+backend best matches your taxonomic / temporal needs. Document the
+choice. Call <code><a href="../reference/pr_cite_tree.html">pr_cite_tree()</a></code> to capture the citation:</p>
 <div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="fu"><a href="../reference/pr_cite_tree.html">pr_cite_tree</a></span><span class="op">(</span><span class="va">res_fishtree</span>, format <span class="op">=</span> <span class="st">"markdown"</span><span class="op">)</span></span></code></pre></div>
 </div>
@@ -300,8 +401,11 @@ reflect the tree-choice uncertainty honestly.</p>
 <div class="section level3">
 <h3 id="when-branch-length-correlation-is-low">When branch-length correlation is low<a class="anchor" aria-label="anchor" href="#when-branch-length-correlation-is-low"></a>
 </h3>
-<p>The trees agree on topology but not on rate scale. Usually one is
-time-calibrated and the other isn’t:</p>
+<p>The trees agree on topology but not on <strong>branch-length
+scale</strong>. Usually that is because one tree is time-calibrated
+(branch lengths in millions of years) and the other is not (branch
+lengths in unit-length placeholders, or in Grafen-units, or in some
+other non-time scale):</p>
 <ul>
 <li>
 <code>rotl</code> returns the synthesis tree with no
@@ -399,7 +503,20 @@ vignette</a> for the prepR4pcm → pigauto integration.</li>
 
 
 
-
-
-  </body>
+  <script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pkgdown emits ```mermaid``` as <pre class="mermaid"><code>...</code></pre>
+  // (or, for some pandoc paths, <pre><code class="language-mermaid">).
+  // Mermaid.js wants <div class="mermaid"> with raw text content, so we
+  // unwrap the <code> and replace the <pre> with a <div>.
+  document.querySelectorAll('pre.mermaid > code, pre > code.language-mermaid').forEach((codeEl) => {
+    const pre = codeEl.parentElement;
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = codeEl.textContent;
+    pre.replaceWith(div);
+  });
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral', securityLevel: 'loose' });
+</script>
+</body>
 </html>

--- a/docs/articles/meta-analysis-with-rotl.html
+++ b/docs/articles/meta-analysis-with-rotl.html
@@ -25,7 +25,7 @@
 
     <a class="navbar-brand me-2" href="../index.html">prepR4pcm</a>
 
-    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Released version">0.4.0.9000</small>
+    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">0.4.0.9000</small>
 
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -77,8 +77,9 @@
 <p>Phylogenetic meta-analysis is the dominant comparative workflow in
 ecology and evolutionary biology when the dataset spans many higher
 taxa: you compute an effect size per study, then fit a model that
-controls for shared evolutionary history. The standard recipe (Cinar et
-al. 2022, <em>Methods Ecol. Evol.</em> 13:383) looks like:</p>
+controls for shared evolutionary history.</p>
+<p>The standard recipe (Cinar et al. 2022, <em>Methods Ecol. Evol.</em>
+13:383) looks like:</p>
 <ol style="list-style-type: decimal">
 <li>
 <strong>Pull a topology from Open Tree of Life</strong> via
@@ -104,8 +105,9 @@ branches are available.</li>
 <code>brms</code>, <code>glmmTMB</code>, etc.) using the correlation
 matrix as a random-effect structure.</li>
 </ol>
-<p><code>prepR4pcm</code> wraps steps 1-3 into a one-call form, and step
-4 into a named helper. This vignette walks through the whole
+<p><code>prepR4pcm</code> wraps steps 1-3 into a single
+<code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> call, and step 4 into a single
+<code><a href="../reference/pr_phylo_cor.html">pr_phylo_cor()</a></code> call. This vignette walks through the whole
 pipeline.</p>
 <div class="section level2">
 <h2 id="a-worked-example-thermal-tolerance-plasticity-across-animal-classes">A worked example: thermal-tolerance plasticity across animal
@@ -116,25 +118,42 @@ classes<a class="anchor" aria-label="anchor" href="#a-worked-example-thermal-tol
 Letters</em> 25(10):2245-2268, <a href="https://doi.org/10.1111/ele.14083" class="external-link">doi:10.1111/ele.14083</a>).
 Their dataset spans <strong>147 ectotherm species across 14 animal
 classes</strong> — fish, insects, reptiles, amphibians, crustaceans,
-bivalves, echinoderms, cephalopods, etc. This is exactly the cross-taxon
-case where rotl is the only practical option (no taxon-specific
-mega-tree covers all 14 classes).</p>
-<p>For brevity, we’ll use 13 representative species — one or two from
-each major class in the Pottier dataset:</p>
+bivalves, echinoderms, cephalopods, etc.</p>
+<p>This is the cross-taxon case where <code>rotl</code> is the only
+practical option for retrieval. The taxon-specific mega-tree backends
+each cover one clade only: <code>rtrees</code> ships separate mega-trees
+for mammals, birds, fish, amphibians, squamates and a handful of other
+taxa; <code>fishtree</code> covers ray-finned fish only;
+<code>clootl</code> covers birds only. None of those backends spans the
+14-class breadth of an ectotherm meta-analysis. The Open Tree of Life
+synthesis tree that <code>source = "rotl"</code> returns is the only
+single backend that places species drawn from every class in one
+tree.</p>
 </div>
 <div class="section level2">
 <h2 id="setup">Setup<a class="anchor" aria-label="anchor" href="#setup"></a>
 </h2>
+<p>We will use three packages: <strong>prepR4pcm</strong> (this package,
+for the retrieve / clean / correlate pipeline), <strong>rotl</strong>
+(the Open Tree of Life client that
+<code>pr_get_tree(source = "rotl")</code> calls under the hood), and
+<strong>metafor</strong> (the meta-analysis engine that consumes the
+phylogenetic correlation matrix).</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/itchyshin/prepR4pcm" class="external-link">prepR4pcm</a></span><span class="op">)</span></span>
-<span><span class="co"># Suggested for the analysis itself:</span></span>
-<span><span class="co"># install.packages("rotl")     # OTL access</span></span>
-<span><span class="co"># install.packages("metafor")  # the meta-analysis engine</span></span></code></pre></div>
+<span><span class="co"># install.packages("rotl")     # required: OTL access (called by pr_get_tree)</span></span>
+<span><span class="co"># install.packages("metafor")  # required: the meta-analysis engine</span></span></code></pre></div>
 </div>
 <div class="section level2">
 <h2 id="step-1-3-topology---bifurcating---grafen-branches-in-one-call">Step 1-3: topology -&gt; bifurcating -&gt; Grafen branches, in one
 call<a class="anchor" aria-label="anchor" href="#step-1-3-topology---bifurcating---grafen-branches-in-one-call"></a>
 </h2>
+<p>For brevity we use <strong>14 representative species</strong> — one
+or two from each major class in the Pottier dataset. Each class label
+below points at one or two species drawn from a different chunk of the
+ectotherm tree. We picked these classes because they are the ones
+contributing the most studies in Pottier et al. (2022); a real analysis
+would use all 147 species from the Pottier dataset.</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">species</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span></span>
 <span>  <span class="co"># Actinopterygii (ray-finned fish)</span></span>
@@ -160,45 +179,96 @@ call<a class="anchor" aria-label="anchor" href="#step-1-3-topology---bifurcating
 <span>  <span class="co"># Hyperoartia (lampreys)</span></span>
 <span>  <span class="st">"Petromyzon marinus"</span></span>
 <span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">species</span><span class="op">)</span>   <span class="co"># 14</span></span></code></pre></div>
+<div class="section level3">
+<h3 id="the-manual-pipeline-without-prepr4pcm">The manual pipeline (without prepR4pcm)<a class="anchor" aria-label="anchor" href="#the-manual-pipeline-without-prepr4pcm"></a>
+</h3>
+<p>Before introducing the wrapper, here is the <strong>manual
+pipeline</strong> the Pottier et al. (2022) methods describe. It calls
+<code><a href="https://docs.ropensci.org/rotl/reference/tnrs_match_names.html" class="external-link">rotl::tnrs_match_names()</a></code> →
+<code><a href="https://docs.ropensci.org/rotl/reference/tol_induced_subtree.html" class="external-link">rotl::tol_induced_subtree()</a></code> →
+<code>ape::multi2di(random = TRUE)</code> →
+<code>ape::compute.brlen(method = "Grafen", power = 1)</code>. We use
+the <code>_manual</code> suffix on every object so the wrapper version
+below can sit next to it without overwriting anything:</p>
+<div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="co"># Step 1: get the rotl topology (no extras)</span></span>
+<span><span class="va">res_manual</span>    <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"rotl"</span><span class="op">)</span></span>
+<span><span class="va">tree_manual</span>   <span class="op">&lt;-</span> <span class="va">res_manual</span><span class="op">$</span><span class="va">tree</span></span>
 <span></span>
-<span><span class="va">res</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span></span>
+<span><span class="co"># Step 2: resolve polytomies at random (bifurcating tree)</span></span>
+<span><span class="va">tree_manual</span>   <span class="op">&lt;-</span> <span class="fu">ape</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/ape/man/multi2di.html" class="external-link">multi2di</a></span><span class="op">(</span><span class="va">tree_manual</span>, random <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span>
+<span></span>
+<span><span class="co"># Step 3: Grafen branch lengths</span></span>
+<span><span class="va">tree_manual</span>   <span class="op">&lt;-</span> <span class="fu">ape</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/ape/man/compute.brlen.html" class="external-link">compute.brlen</a></span><span class="op">(</span><span class="va">tree_manual</span>, method <span class="op">=</span> <span class="st">"Grafen"</span><span class="op">)</span></span>
+<span></span>
+<span><span class="va">res_manual</span><span class="op">$</span><span class="va">tree</span> <span class="op">&lt;-</span> <span class="va">tree_manual</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">tree_manual</span><span class="op">)</span></span></code></pre></div>
+</div>
+<div class="section level3">
+<h3 id="the-same-in-one-call-with-prepr4pcm">The same in one call (with prepR4pcm)<a class="anchor" aria-label="anchor" href="#the-same-in-one-call-with-prepr4pcm"></a>
+</h3>
+<p><code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> with <code>source = "rotl"</code>,
+<code>resolve_polytomies = TRUE</code>, and
+<code>branch_lengths = "grafen"</code> collapses the three steps above
+into one call:</p>
+<div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="va">res</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span></span>
 <span>  <span class="va">species</span>,</span>
 <span>  source             <span class="op">=</span> <span class="st">"rotl"</span>,</span>
 <span>  resolve_polytomies <span class="op">=</span> <span class="cn">TRUE</span>,        <span class="co"># multi2di(random = TRUE)</span></span>
 <span>  branch_lengths     <span class="op">=</span> <span class="st">"grafen"</span>     <span class="co"># compute.brlen(method = "Grafen")</span></span>
 <span><span class="op">)</span></span>
-<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span>           <span class="co"># ultrametric, bifurcating, Grafen branches</span></span>
-<span><span class="va">res</span><span class="op">$</span><span class="va">matched</span>        <span class="co"># species OTL successfully resolved</span></span>
-<span><span class="va">res</span><span class="op">$</span><span class="va">unmatched</span>      <span class="co"># species OTL couldn't place</span></span></code></pre></div>
-<p>The Pottier et al. methods description matches this almost exactly;
-they wrote the pipeline out in <code><a href="https://docs.ropensci.org/rotl/reference/tnrs_match_names.html" class="external-link">rotl::tnrs_match_names()</a></code> →
-<code><a href="https://docs.ropensci.org/rotl/reference/tol_induced_subtree.html" class="external-link">rotl::tol_induced_subtree()</a></code> →
-<code>ape::multi2di(random = TRUE)</code> →
-<code>ape::compute.brlen(method = "Grafen", power = 1)</code> →
-<code>ape::vcv(cor = TRUE)</code>. The two new arguments to
-<code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> collapse those four lines (steps 2-4) into
-one.</p>
-<p>The two new arguments — <code>resolve_polytomies</code> and
-<code>branch_lengths</code> — collapse what would otherwise be three
-explicit pipeline steps:</p>
-<div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span><span class="co"># What `pr_get_tree(... resolve_polytomies = TRUE,</span></span>
-<span><span class="co">#                       branch_lengths   = "grafen")`</span></span>
-<span><span class="co"># is equivalent to (when source = "rotl"):</span></span>
-<span><span class="va">res</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"rotl"</span><span class="op">)</span>  <span class="co"># rotl topology</span></span>
-<span><span class="va">tr</span>  <span class="op">&lt;-</span> <span class="va">res</span><span class="op">$</span><span class="va">tree</span></span>
-<span><span class="va">tr</span>  <span class="op">&lt;-</span> <span class="fu">ape</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/ape/man/multi2di.html" class="external-link">multi2di</a></span><span class="op">(</span><span class="va">tr</span>, random <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span>        <span class="co"># bifurcate</span></span>
-<span><span class="va">tr</span>  <span class="op">&lt;-</span> <span class="fu">ape</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/ape/man/compute.brlen.html" class="external-link">compute.brlen</a></span><span class="op">(</span><span class="va">tr</span>, method <span class="op">=</span> <span class="st">"Grafen"</span><span class="op">)</span></span>
-<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span> <span class="op">&lt;-</span> <span class="va">tr</span></span></code></pre></div>
+<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span>            <span class="co"># ultrametric, bifurcating, Grafen branches</span></span>
+<span><span class="va">res</span><span class="op">$</span><span class="va">matched</span>         <span class="co"># species OTL successfully resolved</span></span>
+<span><span class="va">res</span><span class="op">$</span><span class="va">unmatched</span>       <span class="co"># species OTL couldn't place</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span>      <span class="co"># visualise the topology</span></span>
+<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span>  <span class="co"># has _ott&lt;digits&gt; suffixes (see note below)</span></span></code></pre></div>
+<p><strong>About the <code>_ott&lt;digits&gt;</code> suffixes.</strong>
+Open Tree of Life identifies every taxon by an OTT id
+(e.g. <code>Salmo_trutta_ott854188</code>). <code>rotl</code> appends
+that id to the tip label so a downstream tool can verify which OTT node
+was placed. The suffix is informative for provenance but it makes the
+tip labels disagree with the binomial names you almost certainly have in
+your trait data frame (<code>"Salmo trutta"</code> vs
+<code>"Salmo_trutta_ott854188"</code>). The meta-analysis step below
+strips the suffix and converts underscores to spaces before computing
+the correlation matrix.</p>
+</div>
+<div class="section level3">
+<h3 id="confirm-the-two-pipelines-produce-the-same-tree">Confirm the two pipelines produce the same tree<a class="anchor" aria-label="anchor" href="#confirm-the-two-pipelines-produce-the-same-tree"></a>
+</h3>
+<div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="co"># Same tip set?</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/sets.html" class="external-link">setequal</a></span><span class="op">(</span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span>, <span class="va">res_manual</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span><span class="op">)</span>   <span class="co"># TRUE</span></span>
+<span><span class="co"># Same branch-length range (modulo RNG order for the bifurcation)?</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/range.html" class="external-link">range</a></span><span class="op">(</span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">edge.length</span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/range.html" class="external-link">range</a></span><span class="op">(</span><span class="va">res_manual</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">edge.length</span><span class="op">)</span></span>
+<span><span class="co"># Side-by-side plot</span></span>
+<span><span class="va">op</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/graphics/par.html" class="external-link">par</a></span><span class="op">(</span>mfrow <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="fl">1</span>, <span class="fl">2</span><span class="op">)</span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">res_manual</span><span class="op">$</span><span class="va">tree</span>, main <span class="op">=</span> <span class="st">"manual ape pipeline"</span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html" class="external-link">plot</a></span><span class="op">(</span><span class="va">res</span><span class="op">$</span><span class="va">tree</span>,        main <span class="op">=</span> <span class="st">"one-call pr_get_tree()"</span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/graphics/par.html" class="external-link">par</a></span><span class="op">(</span><span class="va">op</span><span class="op">)</span></span></code></pre></div>
+</div>
 </div>
 <div class="section level2">
 <h2 id="step-4-phylogenetic-correlation-matrix">Step 4: phylogenetic correlation matrix<a class="anchor" aria-label="anchor" href="#step-4-phylogenetic-correlation-matrix"></a>
 </h2>
-<div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
+<p>The tree currently has <code>_ott&lt;digits&gt;</code> suffixes and
+underscores in its tip labels. Strip those before computing the
+correlation matrix so the row / column names match the binomials in your
+trait data:</p>
+<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/grep.html" class="external-link">gsub</a></span><span class="op">(</span><span class="st">"_ott\\d+"</span>, <span class="st">""</span>, <span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span><span class="op">)</span></span>
+<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/grep.html" class="external-link">gsub</a></span><span class="op">(</span><span class="st">"_"</span>,        <span class="st">" "</span>,  <span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span><span class="op">)</span></span>
+<span><span class="va">res</span><span class="op">$</span><span class="va">tree</span><span class="op">$</span><span class="va">tip.label</span>                          <span class="co"># now "Salmo trutta", etc.</span></span></code></pre></div>
+<p>Now compute the phylogenetic correlation matrix:</p>
+<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">phy_cor</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_phylo_cor.html">pr_phylo_cor</a></span><span class="op">(</span><span class="va">res</span><span class="op">)</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/dim.html" class="external-link">dim</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span>            <span class="co"># 9 x 9 (one row/col per species)</span></span>
-<span><span class="fu"><a href="https://rdrr.io/pkg/Matrix/man/isSymmetric-methods.html" class="external-link">isSymmetric</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span>    <span class="co"># TRUE</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/all.html" class="external-link">all</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/diag.html" class="external-link">diag</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span> <span class="op">==</span> <span class="fl">1</span><span class="op">)</span> <span class="co"># TRUE (correlation matrix; ultrametric tree)</span></span></code></pre></div>
+<span><span class="fu"><a href="https://rdrr.io/r/base/dim.html" class="external-link">dim</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span>            <span class="co"># 14 x 14 (one row/col per species)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/isSymmetric.html" class="external-link">isSymmetric</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span>    <span class="co"># TRUE</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/all.html" class="external-link">all</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/diag.html" class="external-link">diag</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span> <span class="op">==</span> <span class="fl">1</span><span class="op">)</span> <span class="co"># TRUE (correlation matrix; ultrametric tree)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">rownames</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span>       <span class="co"># matches the binomials in `species`</span></span></code></pre></div>
 <p><code><a href="../reference/pr_phylo_cor.html">pr_phylo_cor()</a></code> is a thin wrapper around
 <code>ape::vcv(tree, corr = TRUE)</code>. The function exists separately
 so the meta-analysis pattern is self-documenting and so the matrix can
@@ -213,18 +283,26 @@ temperatures. Sampling variance comes with each effect via the group
 sample sizes / SDs. Suppose you’ve already extracted those per-study,
 per-species (this is the realistic shape of an
 ectotherm-thermal-tolerance dataset):</p>
-<div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va"><a href="https://www.metafor-project.org" class="external-link">metafor</a></span><span class="op">)</span></span>
 <span></span>
-<span><span class="co"># Toy effect-size data --- one row per study; one or more rows per</span></span>
-<span><span class="co"># species. Replace with your real extraction.</span></span>
+<span><span class="co"># Toy effect-size data. Start by including every species at least</span></span>
+<span><span class="co"># once (otherwise random sampling can leave some species out and</span></span>
+<span><span class="co"># rma.mv complains about "levels in species without matching rows</span></span>
+<span><span class="co"># in R"). Then add 16 extra studies sampled with replacement to get</span></span>
+<span><span class="co"># a realistic multi-study-per-species shape.</span></span>
 <span><span class="fu"><a href="https://rdrr.io/r/base/Random.html" class="external-link">set.seed</a></span><span class="op">(</span><span class="fl">42</span><span class="op">)</span></span>
 <span><span class="va">toy_df</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/data.frame.html" class="external-link">data.frame</a></span><span class="op">(</span></span>
-<span>  species <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/sample.html" class="external-link">sample</a></span><span class="op">(</span><span class="va">species</span>, <span class="fl">30</span>, replace <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span>,</span>
+<span>  species <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="va">species</span>,                          <span class="co"># 14 guaranteed rows</span></span>
+<span>              <span class="fu"><a href="https://rdrr.io/r/base/sample.html" class="external-link">sample</a></span><span class="op">(</span><span class="va">species</span>, <span class="fl">16</span>, replace <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span><span class="op">)</span>,  <span class="co"># 16 extra</span></span>
 <span>  study   <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/sprintf.html" class="external-link">sprintf</a></span><span class="op">(</span><span class="st">"study_%02d"</span>, <span class="fu"><a href="https://rdrr.io/r/base/seq.html" class="external-link">seq_len</a></span><span class="op">(</span><span class="fl">30</span><span class="op">)</span><span class="op">)</span>,</span>
 <span>  yi      <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/stats/Normal.html" class="external-link">rnorm</a></span><span class="op">(</span><span class="fl">30</span>, mean <span class="op">=</span> <span class="fl">0.20</span>, sd <span class="op">=</span> <span class="fl">0.15</span><span class="op">)</span>,   <span class="co"># lnRR</span></span>
 <span>  vi      <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/stats/Uniform.html" class="external-link">runif</a></span><span class="op">(</span><span class="fl">30</span>, min <span class="op">=</span> <span class="fl">0.01</span>, max <span class="op">=</span> <span class="fl">0.08</span><span class="op">)</span>    <span class="co"># sampling variance</span></span>
 <span><span class="op">)</span></span>
+<span></span>
+<span><span class="co"># Sanity-check: every species in the data is also a row in phy_cor.</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/stopifnot.html" class="external-link">stopifnot</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/all.html" class="external-link">all</a></span><span class="op">(</span><span class="va">toy_df</span><span class="op">$</span><span class="va">species</span> <span class="op"><a href="https://rdrr.io/r/base/match.html" class="external-link">%in%</a></span> <span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">rownames</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/sets.html" class="external-link">intersect</a></span><span class="op">(</span><span class="va">toy_df</span><span class="op">$</span><span class="va">species</span>, <span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">rownames</a></span><span class="op">(</span><span class="va">phy_cor</span><span class="op">)</span><span class="op">)</span><span class="op">)</span>   <span class="co"># 14</span></span>
 <span></span>
 <span><span class="co"># Fit: random study effect (within-study) + random species effect</span></span>
 <span><span class="co"># (between-species, with phylogenetic correlation structure).</span></span>
@@ -237,6 +315,32 @@ ectotherm-thermal-tolerance dataset):</p>
 <span>  method  <span class="op">=</span> <span class="st">"REML"</span></span>
 <span><span class="op">)</span></span>
 <span><span class="fu"><a href="https://rdrr.io/r/base/summary.html" class="external-link">summary</a></span><span class="op">(</span><span class="va">fit</span><span class="op">)</span></span></code></pre></div>
+<p><strong>Alternative: align tree and data via <code>reconcile_*</code>
+first.</strong> If your trait data has species that aren’t in the tree
+(typos, synonyms, OTL gaps), the manual cleanup above won’t catch them.
+A more robust pattern uses <code><a href="../reference/reconcile_tree.html">reconcile_tree()</a></code> +
+<code><a href="../reference/reconcile_apply.html">reconcile_apply()</a></code> on the cleaned tree to drop unresolved
+species and produce a pair guaranteed to match:</p>
+<div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="va">result</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/reconcile_tree.html">reconcile_tree</a></span><span class="op">(</span></span>
+<span>  x         <span class="op">=</span> <span class="va">toy_df</span>,</span>
+<span>  tree      <span class="op">=</span> <span class="va">res</span><span class="op">$</span><span class="va">tree</span>,    <span class="co"># already gsub-cleaned, see Step 4</span></span>
+<span>  x_species <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>  authority <span class="op">=</span> <span class="cn">NULL</span>          <span class="co"># skip synonym lookup; tree labels already binomials</span></span>
+<span><span class="op">)</span></span>
+<span><span class="va">aligned</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/reconcile_apply.html">reconcile_apply</a></span><span class="op">(</span></span>
+<span>  <span class="va">result</span>,</span>
+<span>  data            <span class="op">=</span> <span class="va">toy_df</span>,</span>
+<span>  tree            <span class="op">=</span> <span class="va">res</span><span class="op">$</span><span class="va">tree</span>,</span>
+<span>  species_col     <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>  drop_unresolved <span class="op">=</span> <span class="cn">TRUE</span></span>
+<span><span class="op">)</span></span>
+<span><span class="va">phy_cor</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_phylo_cor.html">pr_phylo_cor</a></span><span class="op">(</span><span class="va">aligned</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span></span>
+<span><span class="va">fit</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://wviechtb.github.io/metafor/reference/rma.mv.html" class="external-link">rma.mv</a></span><span class="op">(</span><span class="va">yi</span> <span class="op">~</span> <span class="fl">1</span>, <span class="va">vi</span>,</span>
+<span>              random <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span><span class="op">~</span><span class="fl">1</span> <span class="op">|</span> <span class="va">study</span>, <span class="op">~</span><span class="fl">1</span> <span class="op">|</span> <span class="va">species</span><span class="op">)</span>,</span>
+<span>              R      <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span>species <span class="op">=</span> <span class="va">phy_cor</span><span class="op">)</span>,</span>
+<span>              data   <span class="op">=</span> <span class="va">aligned</span><span class="op">$</span><span class="va">data</span>,</span>
+<span>              method <span class="op">=</span> <span class="st">"REML"</span><span class="op">)</span></span></code></pre></div>
 <p>The <code>R = list(species = phy_cor)</code> argument is what tells
 <code>metafor</code> that the species random effect has the correlation
 structure given by your phylogeny. The <code>~1 | study</code>
@@ -255,11 +359,11 @@ al. ran into this with <em>Potamilus alatus</em> (a freshwater mussel) —
 OTL’s induced subtree errored on it, so they pulled it out of the tnrs
 match, generated the tree without it, then grafted it back manually with
 <code>ape::bind.tip()</code>:</p>
-<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Pottier et al.'s approach (paraphrased from their Rmd)</span></span>
-<span><span class="va">taxa.tree</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://dplyr.tidyverse.org/reference/filter.html" class="external-link">filter</a></span><span class="op">(</span><span class="va">taxa</span>, <span class="va">ott_id</span> <span class="op">!=</span> <span class="st">"732215"</span><span class="op">)</span> <span class="co"># remove Potamilus alatus</span></span>
+<span><span class="va">taxa.tree</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/stats/filter.html" class="external-link">filter</a></span><span class="op">(</span><span class="va">taxa</span>, <span class="va">ott_id</span> <span class="op">!=</span> <span class="st">"732215"</span><span class="op">)</span> <span class="co"># remove Potamilus alatus</span></span>
 <span><span class="va">phylo_tree</span> <span class="op">&lt;-</span> <span class="fu">tol_induced_subtree</span><span class="op">(</span>ott_ids <span class="op">=</span> <span class="va">taxa.tree</span><span class="op">$</span><span class="va">ott_id</span><span class="op">)</span></span>
-<span><span class="va">binary.tree</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/pkg/ape/man/multi2di.html" class="external-link">multi2di</a></span><span class="op">(</span><span class="va">phylo_tree</span>, random <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span>
+<span><span class="va">binary.tree</span> <span class="op">&lt;-</span> <span class="fu">multi2di</span><span class="op">(</span><span class="va">phylo_tree</span>, random <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span>
 <span><span class="va">binary.tree</span> <span class="op">&lt;-</span> <span class="fu">bind.tip</span><span class="op">(</span><span class="va">binary.tree</span>, tip.label <span class="op">=</span> <span class="st">"Potamilus_alatus"</span>,</span>
 <span>                        where <span class="op">=</span> <span class="fl">95</span><span class="op">)</span>            <span class="co"># grafted into Bivalvia</span></span></code></pre></div>
 <p>In <code>prepR4pcm</code>, the equivalent of “graft species back in”
@@ -268,7 +372,7 @@ gives you the OTL-resolved tree, call <code><a href="../reference/reconcile_augm
 with the residually unresolved species; it does the genus-level (or
 MRCA-level) placement automatically and records the placement in
 <code>$augmented</code> for the methods section:</p>
-<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Step 0 in your workflow: reconcile data names against the tree.</span></span>
 <span><span class="co"># Any species OTL didn't place lands in `unresolved`; you can</span></span>
 <span><span class="co"># graft them onto the tree as sister to a congener (genus-level</span></span>
@@ -290,7 +394,7 @@ Taxonomic Information System.”</p>
 </h2>
 <p>In principle you could replace Grafen branches with biologically real
 ones from datelife:</p>
-<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb12"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Alternative: get rotl topology, then date it with datelife</span></span>
 <span><span class="va">res</span>    <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">species</span>, source <span class="op">=</span> <span class="st">"rotl"</span>,</span>
 <span>                      resolve_polytomies <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span>   <span class="co"># NO branch_lengths</span></span>
@@ -412,7 +516,20 @@ Soc. B 326: 119–157. <a href="https://doi.org/10.1098/rstb.1989.0106" class="e
 
 
 
-
-
-  </body>
+  <script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pkgdown emits ```mermaid``` as <pre class="mermaid"><code>...</code></pre>
+  // (or, for some pandoc paths, <pre><code class="language-mermaid">).
+  // Mermaid.js wants <div class="mermaid"> with raw text content, so we
+  // unwrap the <code> and replace the <pre> with a <div>.
+  document.querySelectorAll('pre.mermaid > code, pre > code.language-mermaid').forEach((codeEl) => {
+    const pre = codeEl.parentElement;
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = codeEl.textContent;
+    pre.replaceWith(div);
+  });
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral', securityLevel: 'loose' });
+</script>
+</body>
 </html>

--- a/vignettes/comparing-tree-backends.Rmd
+++ b/vignettes/comparing-tree-backends.Rmd
@@ -27,10 +27,33 @@ would have given.
 
 ## Setup
 
+Comparison requires multiple tree-retrieval backends installed. Each
+backend lives in a different package because each draws on a
+different reference tree or taxonomy:
+
+- **`rotl`** (CRAN): client for the Open Tree of Life synthesis tree
+  — the only backend with universal taxon coverage. Required for
+  `source = "rotl"`.
+- **`fishtree`** (CRAN): wraps the Rabosky et al. (2018)
+  time-calibrated ray-finned fish phylogeny. Required for
+  `source = "fishtree"`.
+- **`rtrees`** (GitHub only): grafts species onto taxon-specific
+  mega-trees (mammals, birds, fish, amphibians, etc.). Required for
+  `source = "rtrees"`.
+- **`clootl`** (GitHub only): supplies the Clements bird-taxonomy
+  phylogeny. Required for `source = "clootl"`.
+- **`datelife`** (GitHub only): synthesis chronograms from many
+  per-clade published trees. Required for `source = "datelife"`.
+
+Install whichever you need. CRAN packages first, then GitHub-only
+backends via `pak`:
+
 ```{r setup, eval = TRUE}
 library(prepR4pcm)
-# install.packages(c("rotl", "fishtree"))
-# pak::pak(c("eliotmiller/clootl", "daijiang/rtrees", "phylotastic/datelife"))
+# install.packages(c("rotl", "fishtree"))                 # CRAN
+# pak::pak("daijiang/rtrees")                             # GitHub
+# pak::pak("eliotmiller/clootl")                          # GitHub
+# pak::pak("phylotastic/datelife")                        # GitHub (heavy)
 ```
 
 Check what's installed and reachable in your session:
@@ -54,6 +77,17 @@ res_fishtree <- pr_get_tree(species, source = "fishtree")
 res_rtrees   <- pr_get_tree(species, source = "rtrees", taxon = "fish")
 ```
 
+**About the `TNRS replaced ...` warning.** `pr_get_tree()` runs the
+Open Tree of Life Taxonomic Name Resolution Service (TNRS) on the
+input names before passing them to the backend, so that minor
+spelling or capitalisation differences don't cause a name to fall
+out of the tree silently. When TNRS finds a canonical form that
+differs from the input (e.g. an old binomial replaced by the
+current synonym), the wrapper substitutes the canonical form and
+emits a warning listing each replacement, so the substitution is
+visible in the run log. The retrieval still succeeds; the warning is
+informational.
+
 The three results are independent. Now compare:
 
 ```{r compare}
@@ -65,22 +99,47 @@ cmp <- pr_tree_compare(
 cmp
 ```
 
-The print method shows three pairwise matrices. Reading them:
+The print method shows up to three pairwise matrices, depending on
+what is computable for your set of trees. Reading them:
 
 - **Tip-set Jaccard** — fraction of species both trees place. 1.0 =
   same species set. 0.0 = no overlap. If any pairwise value is < 1,
-  you're not comparing apples to apples.
+  the two trees do not cover the same species set, so the
+  topological comparison below is restricted to the species both
+  trees include.
 - **Robinson-Foulds distance** — number of internal edges that
   differ between the two trees, restricted to their shared tip set.
-  Lower = trees agree more.
+  Lower = trees agree more. **`NA` off-diagonal** means the
+  shared-tip subtree has fewer than four taxa (Robinson-Foulds is
+  undefined below four shared tips), or one of the input trees
+  could not be pruned to the shared subtree without becoming
+  degenerate. Diagonal values are always 0 (a tree against itself).
 - **Branch-length correlation** — Pearson correlation of sorted
   edge lengths after pruning to the shared subtree. Useful as a
-  rough check on whether two chronograms agree on rate scale.
+  rough check on whether two chronograms use the same
+  branch-length scale (e.g. millions of years vs unit-length
+  placeholders). **This matrix is only printed when at least one
+  pair has computable branch lengths on both sides.** If `rotl`
+  trees (which carry unit-length placeholder branches) are part of
+  the comparison, the matrix may collapse to NA and the print
+  method drops it; that is why you sometimes see only two matrices
+  rather than three.
 
 ## What actually works (status table)
 
 Backends differ in coverage and in what `n_tree > 1` does. Verified
-on a clean macOS R 4.4 install on 2026-05-01:
+on a clean macOS R 4.4 install on 2026-05-01. Column meanings:
+
+- **Backend** — the value you pass as `source = "..."` to
+  `pr_get_tree()`.
+- **Single tree** — does `pr_get_tree(..., n_tree = 1)` (the
+  default) return a single `ape::phylo` object cleanly?
+- **Multi-tree (`n_tree > 1`)** — does the backend support
+  returning a posterior or sample of trees? Some backends ship a
+  single mega-tree and ignore `n_tree`; others support a true
+  posterior sample.
+- **Notes** — backend-specific gotchas worth knowing before you
+  trust the result.
 
 | Backend | Single tree | Multi-tree (`n_tree > 1`) | Notes |
 |---|---|---|---|
@@ -120,13 +179,38 @@ subset via `rtrees` is what you get out of the box, which is
 sufficient for the great majority of phylogenetic comparative
 analyses.
 
+## Note on tip labels before comparing
+
+The three backends use different conventions for tip labels:
+
+- **`rotl`** appends an Open Tree OTT id to each tip
+  (e.g. `Salmo_salar_ott854188`) and lower-cases the binomial.
+- **`fishtree`** returns the canonical binomial with spaces
+  (`Salmo salar`).
+- **`rtrees`** returns the canonical binomial with underscores
+  (`Salmo_salar`).
+
+`pr_tree_compare()` matches tips by **case- and separator-folded
+binomial** (it strips `_ott<digits>`, converts underscores to
+spaces, and lower-cases) before computing Jaccard, so you do not
+need to clean the labels yourself for the comparison to work. The
+folded form is used only for matching; the original tip labels are
+preserved in each tree.
+
+If you intend to use one of the returned trees downstream (e.g.
+feed it to `pr_phylo_cor()` and then to `metafor::rma.mv()`), you
+will usually want to strip those suffixes yourself with
+`gsub("_ott\\d+", "", tree$tip.label)` first. See the
+*meta-analysis-with-rotl* vignette for that workflow.
+
 ## What to do with the result
 
-### When all three agree (Jaccard ≈ 1, RF small)
+### When the backends return the same species set and similar topology (Jaccard ≈ 1, RF small)
 
-Great. Use whichever backend best matches your taxonomic / temporal
-needs. Document the choice. Call `pr_cite_tree()` to capture the
-citation:
+The backends return the same species set (Jaccard ≈ 1) and broadly
+similar topologies (low Robinson-Foulds distance). Pick whichever
+backend best matches your taxonomic / temporal needs. Document the
+choice. Call `pr_cite_tree()` to capture the citation:
 
 ```{r cite}
 pr_cite_tree(res_fishtree, format = "markdown")
@@ -181,8 +265,11 @@ all_trees <- structure(list(res_rotl$tree, res_fishtree$tree,
 
 ### When branch-length correlation is low
 
-The trees agree on topology but not on rate scale. Usually one is
-time-calibrated and the other isn't:
+The trees agree on topology but not on **branch-length scale**.
+Usually that is because one tree is time-calibrated (branch lengths
+in millions of years) and the other is not (branch lengths in
+unit-length placeholders, or in Grafen-units, or in some other
+non-time scale):
 
 - `rotl` returns the synthesis tree with no calibration.
 - `rtrees` grafts onto a reference tree; calibration is whatever the

--- a/vignettes/meta-analysis-with-rotl.Rmd
+++ b/vignettes/meta-analysis-with-rotl.Rmd
@@ -18,8 +18,10 @@ knitr::opts_chunk$set(
 Phylogenetic meta-analysis is the dominant comparative workflow in
 ecology and evolutionary biology when the dataset spans many higher
 taxa: you compute an effect size per study, then fit a model that
-controls for shared evolutionary history. The standard recipe
-(Cinar et al. 2022, *Methods Ecol. Evol.* 13:383) looks like:
+controls for shared evolutionary history.
+
+The standard recipe (Cinar et al. 2022, *Methods Ecol. Evol.*
+13:383) looks like:
 
 1. **Pull a topology from Open Tree of Life** via `rotl`. OTL gives
    you tip labels and branching structure; the edge lengths it
@@ -39,8 +41,9 @@ controls for shared evolutionary history. The standard recipe
    `MCMCglmm`, `brms`, `glmmTMB`, etc.) using the correlation matrix
    as a random-effect structure.
 
-`prepR4pcm` wraps steps 1-3 into a one-call form, and step 4 into a
-named helper. This vignette walks through the whole pipeline.
+`prepR4pcm` wraps steps 1-3 into a single `pr_get_tree()` call, and
+step 4 into a single `pr_phylo_cor()` call. This vignette walks
+through the whole pipeline.
 
 ## A worked example: thermal-tolerance plasticity across animal classes
 
@@ -50,25 +53,42 @@ Letters* 25(10):2245-2268,
 [doi:10.1111/ele.14083](https://doi.org/10.1111/ele.14083)). Their
 dataset spans **147 ectotherm species across 14 animal classes** —
 fish, insects, reptiles, amphibians, crustaceans, bivalves,
-echinoderms, cephalopods, etc. This is exactly the cross-taxon
-case where rotl is the only practical option (no taxon-specific
-mega-tree covers all 14 classes).
+echinoderms, cephalopods, etc.
 
-For brevity, we'll use 13 representative species — one or two from
-each major class in the Pottier dataset:
+This is the cross-taxon case where `rotl` is the only practical
+option for retrieval. The taxon-specific mega-tree backends each
+cover one clade only: `rtrees` ships separate mega-trees for
+mammals, birds, fish, amphibians, squamates and a handful of other
+taxa; `fishtree` covers ray-finned fish only; `clootl` covers birds
+only. None of those backends spans the 14-class breadth of an
+ectotherm meta-analysis. The Open Tree of Life synthesis tree that
+`source = "rotl"` returns is the only single backend that places
+species drawn from every class in one tree.
 
 ## Setup
 
+We will use three packages: **prepR4pcm** (this package, for the
+retrieve / clean / correlate pipeline), **rotl** (the Open Tree of
+Life client that `pr_get_tree(source = "rotl")` calls under the
+hood), and **metafor** (the meta-analysis engine that consumes the
+phylogenetic correlation matrix).
+
 ```{r setup, eval = TRUE}
 library(prepR4pcm)
-# Suggested for the analysis itself:
-# install.packages("rotl")     # OTL access
-# install.packages("metafor")  # the meta-analysis engine
+# install.packages("rotl")     # required: OTL access (called by pr_get_tree)
+# install.packages("metafor")  # required: the meta-analysis engine
 ```
 
 ## Step 1-3: topology -> bifurcating -> Grafen branches, in one call
 
-```{r get-tree}
+For brevity we use **14 representative species** — one or two from
+each major class in the Pottier dataset. Each class label below
+points at one or two species drawn from a different chunk of the
+ectotherm tree. We picked these classes because they are the ones
+contributing the most studies in Pottier et al. (2022); a real
+analysis would use all 147 species from the Pottier dataset.
+
+```{r species-list}
 species <- c(
   # Actinopterygii (ray-finned fish)
   "Salmo trutta",              "Acipenser fulvescens",
@@ -93,46 +113,99 @@ species <- c(
   # Hyperoartia (lampreys)
   "Petromyzon marinus"
 )
+length(species)   # 14
+```
 
+### The manual pipeline (without prepR4pcm)
+
+Before introducing the wrapper, here is the **manual pipeline** the
+Pottier et al. (2022) methods describe. It calls
+`rotl::tnrs_match_names()` →
+`rotl::tol_induced_subtree()` → `ape::multi2di(random = TRUE)` →
+`ape::compute.brlen(method = "Grafen", power = 1)`. We use the
+`_manual` suffix on every object so the wrapper version below can
+sit next to it without overwriting anything:
+
+```{r manual-pipeline, eval = FALSE}
+# Step 1: get the rotl topology (no extras)
+res_manual    <- pr_get_tree(species, source = "rotl")
+tree_manual   <- res_manual$tree
+
+# Step 2: resolve polytomies at random (bifurcating tree)
+tree_manual   <- ape::multi2di(tree_manual, random = TRUE)
+
+# Step 3: Grafen branch lengths
+tree_manual   <- ape::compute.brlen(tree_manual, method = "Grafen")
+
+res_manual$tree <- tree_manual
+plot(tree_manual)
+```
+
+### The same in one call (with prepR4pcm)
+
+`pr_get_tree()` with `source = "rotl"`, `resolve_polytomies = TRUE`,
+and `branch_lengths = "grafen"` collapses the three steps above
+into one call:
+
+```{r get-tree}
 res <- pr_get_tree(
   species,
   source             = "rotl",
   resolve_polytomies = TRUE,        # multi2di(random = TRUE)
   branch_lengths     = "grafen"     # compute.brlen(method = "Grafen")
 )
-res$tree           # ultrametric, bifurcating, Grafen branches
-res$matched        # species OTL successfully resolved
-res$unmatched      # species OTL couldn't place
+res$tree            # ultrametric, bifurcating, Grafen branches
+res$matched         # species OTL successfully resolved
+res$unmatched       # species OTL couldn't place
+plot(res$tree)      # visualise the topology
+res$tree$tip.label  # has _ott<digits> suffixes (see note below)
 ```
 
-The Pottier et al. methods description matches this almost exactly;
-they wrote the pipeline out in `rotl::tnrs_match_names()` →
-`rotl::tol_induced_subtree()` → `ape::multi2di(random = TRUE)` →
-`ape::compute.brlen(method = "Grafen", power = 1)` →
-`ape::vcv(cor = TRUE)`. The two new arguments to `pr_get_tree()`
-collapse those four lines (steps 2-4) into one.
+**About the `_ott<digits>` suffixes.** Open Tree of Life identifies
+every taxon by an OTT id (e.g. `Salmo_trutta_ott854188`). `rotl`
+appends that id to the tip label so a downstream tool can verify
+which OTT node was placed. The suffix is informative for
+provenance but it makes the tip labels disagree with the binomial
+names you almost certainly have in your trait data frame
+(`"Salmo trutta"` vs `"Salmo_trutta_ott854188"`). The
+meta-analysis step below strips the suffix and converts underscores
+to spaces before computing the correlation matrix.
 
-The two new arguments — `resolve_polytomies` and `branch_lengths` —
-collapse what would otherwise be three explicit pipeline steps:
+### Confirm the two pipelines produce the same tree
 
-```{r equiv, eval = FALSE}
-# What `pr_get_tree(... resolve_polytomies = TRUE,
-#                       branch_lengths   = "grafen")`
-# is equivalent to (when source = "rotl"):
-res <- pr_get_tree(species, source = "rotl")  # rotl topology
-tr  <- res$tree
-tr  <- ape::multi2di(tr, random = TRUE)        # bifurcate
-tr  <- ape::compute.brlen(tr, method = "Grafen")
-res$tree <- tr
+```{r compare-pipelines, eval = FALSE}
+# Same tip set?
+setequal(res$tree$tip.label, res_manual$tree$tip.label)   # TRUE
+# Same branch-length range (modulo RNG order for the bifurcation)?
+range(res$tree$edge.length)
+range(res_manual$tree$edge.length)
+# Side-by-side plot
+op <- par(mfrow = c(1, 2))
+plot(res_manual$tree, main = "manual ape pipeline")
+plot(res$tree,        main = "one-call pr_get_tree()")
+par(op)
 ```
 
 ## Step 4: phylogenetic correlation matrix
 
+The tree currently has `_ott<digits>` suffixes and underscores in
+its tip labels. Strip those before computing the correlation matrix
+so the row / column names match the binomials in your trait data:
+
+```{r clean-labels}
+res$tree$tip.label <- gsub("_ott\\d+", "", res$tree$tip.label)
+res$tree$tip.label <- gsub("_",        " ",  res$tree$tip.label)
+res$tree$tip.label                          # now "Salmo trutta", etc.
+```
+
+Now compute the phylogenetic correlation matrix:
+
 ```{r phylo-cor}
 phy_cor <- pr_phylo_cor(res)
-dim(phy_cor)            # 9 x 9 (one row/col per species)
+dim(phy_cor)            # 14 x 14 (one row/col per species)
 isSymmetric(phy_cor)    # TRUE
 all(diag(phy_cor) == 1) # TRUE (correlation matrix; ultrametric tree)
+rownames(phy_cor)       # matches the binomials in `species`
 ```
 
 `pr_phylo_cor()` is a thin wrapper around `ape::vcv(tree, corr =
@@ -151,15 +224,23 @@ ectotherm-thermal-tolerance dataset):
 ```{r meta}
 library(metafor)
 
-# Toy effect-size data --- one row per study; one or more rows per
-# species. Replace with your real extraction.
+# Toy effect-size data. Start by including every species at least
+# once (otherwise random sampling can leave some species out and
+# rma.mv complains about "levels in species without matching rows
+# in R"). Then add 16 extra studies sampled with replacement to get
+# a realistic multi-study-per-species shape.
 set.seed(42)
 toy_df <- data.frame(
-  species = sample(species, 30, replace = TRUE),
+  species = c(species,                          # 14 guaranteed rows
+              sample(species, 16, replace = TRUE)),  # 16 extra
   study   = sprintf("study_%02d", seq_len(30)),
   yi      = rnorm(30, mean = 0.20, sd = 0.15),   # lnRR
   vi      = runif(30, min = 0.01, max = 0.08)    # sampling variance
 )
+
+# Sanity-check: every species in the data is also a row in phy_cor.
+stopifnot(all(toy_df$species %in% rownames(phy_cor)))
+length(intersect(toy_df$species, rownames(phy_cor)))   # 14
 
 # Fit: random study effect (within-study) + random species effect
 # (between-species, with phylogenetic correlation structure).
@@ -172,6 +253,35 @@ fit <- rma.mv(
   method  = "REML"
 )
 summary(fit)
+```
+
+**Alternative: align tree and data via `reconcile_*` first.** If
+your trait data has species that aren't in the tree (typos,
+synonyms, OTL gaps), the manual cleanup above won't catch them.
+A more robust pattern uses `reconcile_tree()` + `reconcile_apply()`
+on the cleaned tree to drop unresolved species and produce a pair
+guaranteed to match:
+
+```{r reconcile-then-fit, eval = FALSE}
+result <- reconcile_tree(
+  x         = toy_df,
+  tree      = res$tree,    # already gsub-cleaned, see Step 4
+  x_species = "species",
+  authority = NULL          # skip synonym lookup; tree labels already binomials
+)
+aligned <- reconcile_apply(
+  result,
+  data            = toy_df,
+  tree            = res$tree,
+  species_col     = "species",
+  drop_unresolved = TRUE
+)
+phy_cor <- pr_phylo_cor(aligned$tree)
+fit <- rma.mv(yi ~ 1, vi,
+              random = list(~1 | study, ~1 | species),
+              R      = list(species = phy_cor),
+              data   = aligned$data,
+              method = "REML")
 ```
 
 The `R = list(species = phy_cor)` argument is what tells `metafor`


### PR DESCRIPTION
Addresses two doc-feedback issues from @mlagisz, both filed against rendered vignette pages on the pkgdown site.

Refs #89, #90. **Does not close either** — leaving for Maja to verify and close.

## Issue #89 — `meta-analysis-with-rotl.html`

All 13 items addressed:

| # | Item | Where |
|---|------|------|
| 1 | Move Cinar citation to end of first sentence, new paragraph for the recipe | opening paragraphs |
| 2 | Replace "named helper" jargon | "wraps step 4 into a single \`pr_phylo_cor()\` call" |
| 3 | Expand "rotl is the only practical option" | added paragraph naming why rtrees / fishtree / clootl each cover one clade only |
| 4 | Species count 13 → 14; move "for brevity" sentence; explain class selection | Step 1-3 section, with \`length(species) # 14\` self-check |
| 5 | Setup section intro | listing the three required packages and why each is needed |
| 6 | "# Suggested for the analysis itself" → "# required: ..." | required, not suggested |
| 7 | Add description before \`pr_get_tree()\` chunk | one-line explanation of what the call does |
| 8 | Add \`plot(res$tree)\`, \`res$tree$tip.label\`, explain \`_ott<digits>\` suffixes | new paragraph titled "About the _ott<digits> suffixes" |
| 9 | Old-way (manual ape pipeline) **before** new-way; distinct object names; explicit comparison | reorganised into two H3 subsections + a "confirm the two pipelines match" chunk |
| 10 | **Live bug fix**: \`rma.mv\` failure because tip labels did not match \`toy_df$species\` | added \`gsub(\"_ott\\\\d+\", ...)\` + \`gsub(\"_\", \" \", ...)\` before \`pr_phylo_cor()\` |
| 11 | Add \`gsub(\"_ott\\\\d+\", \"\", ...)\` step | as above |
| 12 | Add \`gsub(\"_\", \" \", ...)\` step | as above |
| 13 | Sanity-check species overlap; rebuild \`toy_df\` so all species are guaranteed present | new \`toy_df\` includes \`species\` directly + 16 extra random rows; \`stopifnot(all(toy_df$species %in% rownames(phy_cor)))\` |

Also added an *Alternative* code block that demonstrates the more robust \`reconcile_tree()\` + \`reconcile_apply()\` path for users whose trait data has species the tree does not place.

## Issue #90 — \`comparing-tree-backends.html\`

All 8 items addressed:

| # | Item | Where |
|---|------|------|
| 1 | Setup section explains why each package is needed | new bulleted list: rotl, fishtree, rtrees, clootl, datelife |
| 2 | Add \`pak::pak(\"daijiang/rtrees\")\` to install hints; explain \`TNRS replaced ...\` warning | Setup section + new paragraph after the recipe chunk |
| 3 | "I only get two matrices, branch-length correlation missing" | new paragraph: matrix is dropped when no pair has computable branch lengths on both sides (common when rotl is involved) |
| 4 | "apples to apples" idiom → explicit | "the two trees do not cover the same species set, so the topological comparison is restricted to the shared species" |
| 5 | NA off-diagonal in RF matrix | explained: shared tip set < 4 (RF undefined), or tree becomes degenerate after pruning |
| 6 | Status-table column meanings | new intro list with column definitions |
| 7 | "When all three agree" cryptic | replaced with "When the backends return the same species set (Jaccard ≈ 1) and broadly similar topologies (low Robinson-Foulds distance)" |
| 8 | Tree label cleaning before comparison | new "Note on tip labels before comparing" section documenting the three backends' label conventions and \`pr_tree_compare()\`'s case- and separator-folded matching |
| 9 | "rate scale" wording | replaced with "branch-length scale (e.g. millions of years vs unit-length placeholders)" |

## Verification

- Both vignettes are \`eval = FALSE\` at top-of-document (network + heavy backends), so \`R CMD check\` time is unchanged.
- Rendered HTML via \`pkgdown::build_article()\` for both vignettes (\`docs/articles/\*.html\` included).
- Spot-checked the rendered HTML for the new content (gsub cleanup, length(species), \`_ott\` explanation, branch-length-scale wording, etc.).
- Did **not** run the example code end-to-end because it requires rotl + fishtree + rtrees + network. Reviewer (Maja) is best positioned to verify the \`rma.mv\` fix on her real data.

## Test plan

- [x] \`pkgdown::build_article()\` clean for both vignettes
- [x] Spot-check rendered HTML
- [ ] Reviewer (@mlagisz): open the two pkgdown pages and re-run the example chunks; confirm \`rma.mv\` no longer errors on the cleaned tree; close the issue checklists

🤖 Generated with [Claude Code](https://claude.com/claude-code)