### PR TITLE
fix(pr_get_tree): realign TNRS results when normalised names collide

### DIFF
--- a/R/pr_get_tree.R
+++ b/R/pr_get_tree.R
@@ -894,15 +894,27 @@ pr_get_tree <- function(
   tnrs_replacements <- NULL
 
   if (do_tnrs && requireNamespace("rotl", quietly = TRUE)) {
+    # `rotl::tnrs_match_names()` de-duplicates (and may reorder) its
+    # input, so its rows do NOT line up 1:1 with `normalised` when two
+    # distinct inputs normalise to the same string (e.g. "Esox lucius"
+    # and "Esox_lucius" both normalise to "Esox lucius"). Query the
+    # unique normalised names, then realign each result back to every
+    # element of `normalised` by the lowercased `search_string` that
+    # rotl echoes. Comparing `tnrs_res$unique_name` against `normalised`
+    # directly recycles a short vector against a long one and silently
+    # mis-matches species.
+    uniq_norm <- unique(normalised)
     tnrs_res <- tryCatch(
-      rotl::tnrs_match_names(normalised),
+      rotl::tnrs_match_names(uniq_norm),
       error = function(e) NULL
     )
     if (!is.null(tnrs_res) && !is.null(tnrs_res$unique_name)) {
-      replaced_idx <- !is.na(tnrs_res$unique_name) &
-        nzchar(tnrs_res$unique_name) &
-        tnrs_res$unique_name != normalised
-      resolved[replaced_idx] <- tnrs_res$unique_name[replaced_idx]
+      row <- match(tolower(normalised), tnrs_res$search_string)
+      matched_name <- tnrs_res$unique_name[row]
+      replaced_idx <- !is.na(matched_name) &
+        nzchar(matched_name) &
+        matched_name != normalised
+      resolved[replaced_idx] <- matched_name[replaced_idx]
       if (any(replaced_idx)) {
         tnrs_replacements <- stats::setNames(
           resolved[replaced_idx],

--- a/tests/testthat/test-pr_resolve_query-duplicate-normalised.R
+++ b/tests/testthat/test-pr_resolve_query-duplicate-normalised.R
@@ -1,0 +1,88 @@
+# Regression tests: .pr_resolve_query() must realign tnrs_match_names()
+# output to the (possibly duplicated) `normalised` vector.
+#
+# Bug: `rotl::tnrs_match_names()` de-duplicates its input, so when two
+# distinct input names normalise to the same string (e.g. "Esox lucius"
+# and "Esox_lucius" both normalise to "Esox lucius"), the TNRS result
+# had fewer rows than `normalised`. Comparing `tnrs_res$unique_name`
+# against `normalised` then recycled a short vector against a long one
+# ("longer object length is not a multiple of shorter object length")
+# and silently mis-matched species. The fix queries the unique
+# normalised names and realigns by the lowercased `search_string`.
+
+# tnrs_match_names() de-duplicates its input and returns one row per
+# unique name, with a lowercased `search_string`. This mock mirrors
+# that contract; `resolver` lets a test inject name substitutions.
+fake_tnrs_factory <- function(resolver = identity) {
+  function(names, ...) {
+    u <- unique(names)
+    data.frame(
+      search_string = tolower(u),
+      unique_name   = resolver(u),
+      stringsAsFactors = FALSE
+    )
+  }
+}
+
+test_that(".pr_resolve_query realigns TNRS results when normalised names duplicate", {
+  skip_if_not_installed("rotl")
+
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_factory(),  # no substitutions
+    .package = "rotl"
+  )
+
+  # "Esox lucius" and "Esox_lucius" both normalise to "Esox lucius".
+  input <- c("Esox lucius", "Esox_lucius", "Oncorhynchus mykiss")
+
+  expect_no_warning(
+    res <- .pr_resolve_query(input, source = "fishtree", tnrs = "always")
+  )
+  expect_equal(res$original, input)
+  expect_length(res$query, length(input))
+  # each element resolves to its own species, not a shifted neighbour
+  # (ignore_attr: pr_normalize_names() attaches a normalisation_log attr)
+  expect_equal(res$query,
+               c("Esox lucius", "Esox lucius", "Oncorhynchus mykiss"),
+               ignore_attr = TRUE)
+})
+
+test_that(".pr_resolve_query maps a TNRS substitution to the correct species", {
+  skip_if_not_installed("rotl")
+
+  # TNRS rewrites "Esox lucius" -> "Esox reichertii" (stand-in synonym).
+  # Both forms of Esox lucius must pick up the substitute; the unrelated
+  # species must be left alone.
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_factory(
+      function(u) ifelse(u == "Esox lucius", "Esox reichertii", u)
+    ),
+    .package = "rotl"
+  )
+
+  input <- c("Esox lucius", "Esox_lucius", "Oncorhynchus mykiss")
+  # the TNRS-substitution cli warning is expected here; not under test
+  res <- suppressWarnings(
+    .pr_resolve_query(input, source = "fishtree", tnrs = "always")
+  )
+
+  expect_equal(res$query,
+               c("Esox reichertii", "Esox reichertii", "Oncorhynchus mykiss"),
+               ignore_attr = TRUE)
+  # replacement map is keyed by the ORIGINAL input strings
+  expect_setequal(names(res$tnrs_replacements),
+                  c("Esox lucius", "Esox_lucius"))
+})
+
+test_that(".pr_resolve_query is unaffected when no normalised names collide", {
+  skip_if_not_installed("rotl")
+
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_factory(),
+    .package = "rotl"
+  )
+
+  input <- c("Salmo salar", "Esox lucius", "Gadus morhua")
+  res <- .pr_resolve_query(input, source = "fishtree", tnrs = "always")
+  expect_equal(res$query, input, ignore_attr = TRUE)
+})


### PR DESCRIPTION
## The bug

`.pr_resolve_query()` (the TNRS preflight inside `pr_get_tree()`) passed the `normalised` name vector straight to `rotl::tnrs_match_names()`, then compared `tnrs_res$unique_name` against `normalised` element-wise.

`tnrs_match_names()` **de-duplicates its input**. When two distinct inputs normalise to the same string — e.g. `"Esox lucius"` and `"Esox_lucius"` both normalise to `"Esox lucius"` — the TNRS result had fewer rows than `normalised`. The comparison recycled a short vector against a long one (`longer object length is not a multiple of shorter object length`) and the resolved names landed on the **wrong species**.

This silently mis-matches or drops species — the exact failure mode prepR4pcm exists to prevent. Found while auditing the `posterior-tree-pipeline` vignette, whose example data triggers it.

**Reproduced:**
```r
pr_get_tree(c("Esox lucius", "Esox_lucius", "Salmo salar", "Oncorhynchus mykiss"),
            source = "fishtree")
# before: Salmo salar (a valid fishtree species) reported UNMATCHED;
#         'Esox_lucius' -> 'Salmo salar'  (wrong)
# after:  Esox lucius / Esox_lucius / Salmo salar all matched, no warnings
```

## The fix

Query the **unique** normalised names, then realign each result back to every element of `normalised` via the lowercased `search_string` column rotl echoes: `match(tolower(normalised), tnrs_res$search_string)`. Correct whether or not `normalised` has duplicates — the common no-collision path is unchanged.

## Tests

New `tests/testthat/test-pr_resolve_query-duplicate-normalised.R` (3 tests, `rotl` mocked):
- realignment under a normalisation collision (the bug);
- a TNRS substitution routes to the correct species;
- the no-collision path is unaffected.

All pass locally. Live repro confirmed fixed.

## Known separate issue (not fixed here)

With the desync fixed, `Oncorhynchus mykiss` still comes back unmatched because rotl's `unique_name` for it is `"Oncorhynchus mykiss (species in domain Eukaryota)"` — a homonym-disambiguation parenthetical that then fails to match the backend tip. That is a **distinct** bug (TNRS parenthetical qualifiers leaking into the backend query); flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)