### PR TITLE
fix(pr_normalize): strip trailing parenthetical qualifiers from names

### DIFF
--- a/R/pr_get_tree.R
+++ b/R/pr_get_tree.R
@@ -911,6 +911,13 @@ pr_get_tree <- function(
     if (!is.null(tnrs_res) && !is.null(tnrs_res$unique_name)) {
       row <- match(tolower(normalised), tnrs_res$search_string)
       matched_name <- tnrs_res$unique_name[row]
+      # `tnrs_match_names()`'s `unique_name` carries Open Tree homonym /
+      # rank qualifiers (e.g. "Oncorhynchus mykiss (species in domain
+      # Eukaryota)"). Run it back through pr_normalize_names() so the
+      # backend query is a clean binomial; otherwise the qualifier
+      # leaks into the query and the species silently fails to match a
+      # tree tip.
+      matched_name <- as.character(pr_normalize_names(matched_name))
       replaced_idx <- !is.na(matched_name) &
         nzchar(matched_name) &
         matched_name != normalised

--- a/R/pr_normalize.R
+++ b/R/pr_normalize.R
@@ -17,6 +17,9 @@
 #'   \item Strip authority strings and year, including multi-author
 #'     and parenthetical forms (`Corvus corax (Linnaeus, 1758)` ->
 #'     `Corvus corax`).
+#'   \item Strip any other trailing parenthetical qualifier, such as
+#'     the Open Tree of Life homonym / rank flags that `rotl` returns
+#'     (`Prunella (genus in kingdom Archaeplastida)` -> `Prunella`).
 #'   \item Fold diacritics to ASCII (`Passer domesticus` stays as
 #'     `Passer domesticus`; accented characters are simplified).
 #'   \item Standardise case: genus capitalised, epithet lowercase.
@@ -90,6 +93,14 @@ pr_normalize_names <- function(names, rank = c("species", "subspecies")) {
 
   # Also handles "L." or "Author, Year" patterns
   names <- pr_strip_authority(names)
+
+  # 6b. Strip any other trailing parenthetical qualifier. Open Tree of
+  # Life's TNRS appends homonym / rank flags to the `unique_name` it
+  # returns (e.g. "Salmo salar (species in domain Eukaryota)",
+  # "Prunella (genus in kingdom Archaeplastida)"). pr_strip_authority()
+  # only catches the (Author, Year) form; a trailing parenthetical is
+  # never part of a name you would match against a tree tip.
+  names <- sub("\\s*\\([^()]*\\)\\s*$", "", names, perl = TRUE)
 
   # 7. Standardise hybrid signs
   names <- gsub("\\s*\u00d7\\s*", " x ", names)  # multiplication sign

--- a/man/pr_normalize_names.Rd
+++ b/man/pr_normalize_names.Rd
@@ -40,6 +40,9 @@ space (\code{Homo_sapiens} -> \verb{Homo sapiens}).
 \item Strip authority strings and year, including multi-author
 and parenthetical forms (\verb{Corvus corax (Linnaeus, 1758)} ->
 \verb{Corvus corax}).
+\item Strip any other trailing parenthetical qualifier, such as
+the Open Tree of Life homonym / rank flags that \code{rotl} returns
+(\verb{Prunella (genus in kingdom Archaeplastida)} -> \code{Prunella}).
 \item Fold diacritics to ASCII (\verb{Passer domesticus} stays as
 \verb{Passer domesticus}; accented characters are simplified).
 \item Standardise case: genus capitalised, epithet lowercase.

--- a/tests/testthat/test-pr_normalize.R
+++ b/tests/testthat/test-pr_normalize.R
@@ -197,6 +197,30 @@ test_that("authority stripping handles parenthetical and non-parenthetical forms
 })
 
 
+test_that("trailing parenthetical qualifiers (OTL homonym/rank flags) are stripped", {
+  # rotl::tnrs_match_names() returns `unique_name` values with Open Tree
+  # homonym / rank qualifiers appended; these must not survive
+  # normalisation or they leak into a backend query and break matching.
+  cases <- list(
+    list(in_ = "Oncorhynchus mykiss (species in domain Eukaryota)",
+         out = "Oncorhynchus mykiss"),
+    list(in_ = "Prunella (genus in kingdom Archaeplastida)",
+         out = "Prunella"),
+    list(in_ = "Anolis sagrei (genus in kingdom Animalia)",
+         out = "Anolis sagrei"),
+    # a clean binomial is left untouched
+    list(in_ = "Salmo salar", out = "Salmo salar")
+  )
+  for (case in cases) {
+    expect_equal(
+      as.character(pr_normalize_names(case$in_)),
+      case$out,
+      info = sprintf("input: %s", case$in_)
+    )
+  }
+})
+
+
 test_that("rank='subspecies' preserves trinomials and rank-marked forms", {
   cases <- list(
     list(in_ = "Parus major major",                   out = "Parus major major"),

--- a/tests/testthat/test-pr_resolve_query-duplicate-normalised.R
+++ b/tests/testthat/test-pr_resolve_query-duplicate-normalised.R
@@ -86,3 +86,62 @@ test_that(".pr_resolve_query is unaffected when no normalised names collide", {
   res <- .pr_resolve_query(input, source = "fishtree", tnrs = "always")
   expect_equal(res$query, input, ignore_attr = TRUE)
 })
+
+
+# Regression tests: tnrs_match_names()'s `unique_name` carries Open Tree
+# homonym / rank qualifiers (e.g. "Oncorhynchus mykiss (species in
+# domain Eukaryota)"). .pr_resolve_query() must strip these before the
+# resolved name reaches the backend query, and must not mistake a
+# qualifier-only difference for a genuine TNRS substitution.
+
+test_that(".pr_resolve_query strips OTL qualifiers from the resolved query", {
+  skip_if_not_installed("rotl")
+
+  # TNRS echoes each name back with a trailing "(species in domain ...)"
+  # qualifier but makes no genuine substitution.
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_factory(
+      function(u) paste0(u, " (species in domain Eukaryota)")
+    ),
+    .package = "rotl"
+  )
+
+  input <- c("Salmo salar", "Esox lucius")
+  # A qualifier-only difference is not a substitution: no warning fires
+  # and `tnrs_replacements` stays NULL.
+  expect_no_warning(
+    res <- .pr_resolve_query(input, source = "fishtree", tnrs = "always")
+  )
+  expect_equal(res$query, c("Salmo salar", "Esox lucius"),
+               ignore_attr = TRUE)
+  expect_null(res$tnrs_replacements)
+})
+
+test_that(".pr_resolve_query records a genuine substitution with the qualifier stripped", {
+  skip_if_not_installed("rotl")
+
+  # TNRS rewrites "Esox lucius" -> "Esox reichertii" AND tacks on an OTL
+  # rank qualifier. The substitution must be recorded; the qualifier
+  # must not leak into either the query or the replacement map.
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_factory(
+      function(u) ifelse(u == "Esox lucius",
+                         "Esox reichertii (species in domain Eukaryota)",
+                         u)
+    ),
+    .package = "rotl"
+  )
+
+  input <- c("Salmo salar", "Esox lucius")
+  res <- suppressWarnings(
+    .pr_resolve_query(input, source = "fishtree", tnrs = "always")
+  )
+
+  expect_equal(res$query, c("Salmo salar", "Esox reichertii"),
+               ignore_attr = TRUE)
+  # the substitution is recorded, keyed by the original input ...
+  expect_named(res$tnrs_replacements, "Esox lucius")
+  # ... and its value is the clean binomial, not "Esox reichertii (...)"
+  expect_equal(unname(res$tnrs_replacements), "Esox reichertii",
+               ignore_attr = TRUE)
+})


### PR DESCRIPTION
## Summary

- `pr_normalize_names()` now strips **any** trailing parenthetical qualifier, not just `(Author, Year)` authority strings. Open Tree of Life's TNRS appends homonym / rank flags to the `unique_name` it returns (e.g. `Oncorhynchus mykiss (species in domain Eukaryota)`). These previously leaked through `.pr_resolve_query()` into the backend query, so the species silently failed to match a tree tip.
- `.pr_resolve_query()` re-runs the TNRS `unique_name` through `pr_normalize_names()`, so a qualifier-only difference is no longer mistaken for a genuine TNRS substitution — no false `tnrs_replacements` entry, no spurious warning.

## Test plan

- [x] `devtools::test(filter = "pr_normalize|pr_resolve_query")` — 97 pass, 0 fail. New `test-pr_normalize.R` block for OTL homonym/rank flags; two new `.pr_resolve_query` regression blocks (qualifier-only vs. genuine substitution).
- [x] Live check: `pr_get_tree(c("Oncorhynchus mykiss", "Salmo salar", "Esox lucius"), source = "fishtree")` — all three matched with a clean `query_name`, none unmatched. Before the fix `Oncorhynchus mykiss` was unmatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)