### PR TITLE
feat(pr_get_tree): record TNRS match metadata in the mapping table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # prepR4pcm 0.4.0.9000 (development version)
 
+## Round 19: TNRS match metadata in the tree mapping table
+
+* **`pr_get_tree()`'s `result$mapping` now records what TNRS reported
+  for each name.** Four columns are added: `tnrs_number_matches`,
+  `tnrs_is_synonym`, `tnrs_approximate_match`, and `tnrs_flags`,
+  carrying the structured output of `rotl::tnrs_match_names()`. They
+  are `NA` for backends or `tnrs` settings where TNRS did not run, so
+  the mapping schema stays stable across calls. When a name resolves
+  to more than one taxon (`tnrs_number_matches > 1`, a homonym),
+  `pr_get_tree()` emits a one-shot warning naming the affected
+  species, since the resolved name is then only one of several
+  candidates. This extends the Round 17 audit table: a user can see
+  not just which name was queried but how `rotl`'s resolver
+  classified the match.
+
 ## Round 18: mammal_tree_example provenance — Upham et al. 2019
 
 * **`?mammal_tree_example` now cites the source** (#11). The bundled

--- a/R/pr_date_tree.R
+++ b/R/pr_date_tree.R
@@ -87,8 +87,9 @@
 #'   \item{`mapping`}{A tibble with one row per input tip label,
 #'     mirroring [pr_get_tree()]'s audit table: `input_name`,
 #'     `normalized_name`, `query_name`, `tree_name`, `in_tree`,
-#'     `match_type`, and `placement_status` (`NA` for DateLife
-#'     dating).}
+#'     `match_type`, `placement_status`, and the four `tnrs_*`
+#'     columns. `placement_status` and the `tnrs_*` columns are `NA`
+#'     for DateLife dating, which applies no TNRS step.}
 #'   \item{`source`}{Always `"datelife"` (paired with `pr_get_tree()`'s
 #'     dispatch).}
 #'   \item{`backend_meta`}{Includes `dating_method`, `calibrations`

--- a/R/pr_get_tree.R
+++ b/R/pr_get_tree.R
@@ -226,17 +226,22 @@
 #'     `length(matched) + length(unmatched) == length(unique(input))`
 #'     always holds. Inspect these and consider running them back
 #'     through [reconcile_suggest()] / a manual override.}
-#'   \item{`mapping`}{A tibble with one row per unique input species:
-#'     `input_name`, `normalized_name`, `query_name`, `tree_name`,
-#'     `in_tree`, `match_type`, and `placement_status`. This is the
-#'     audit trail for name handling: `input_name` is what the user
-#'     supplied, `normalized_name` is the result of
+#'   \item{`mapping`}{A tibble with one row per unique input species.
+#'     Core columns: `input_name`, `normalized_name`, `query_name`,
+#'     `tree_name`, `in_tree`, `match_type`, and `placement_status`.
+#'     This is the audit trail for name handling: `input_name` is what
+#'     the user supplied, `normalized_name` is the result of
 #'     [pr_normalize_names()], `query_name` is the backend query after
 #'     optional TNRS, `tree_name` is the actual returned tip label, and
 #'     `match_type` is one of `"exact"`, `"normalized"`, `"tnrs"`, or
 #'     `"unmatched"`. For `source = "rtrees"`, `placement_status`
 #'     carries the grafting status from `backend_meta$placement`;
-#'     otherwise it is `NA`.}
+#'     otherwise it is `NA`. Four further columns record what `rotl`'s
+#'     TNRS resolver reported for each name: `tnrs_number_matches`,
+#'     `tnrs_is_synonym`, `tnrs_approximate_match`, and `tnrs_flags`.
+#'     These are `NA` for backends or `tnrs` settings where TNRS did
+#'     not run. `tnrs_number_matches > 1` flags a homonym, meaning the
+#'     resolved name is only one of several candidate taxa.}
 #'   \item{`source`}{The backend that produced the tree.}
 #'   \item{`backend_meta`}{A named list of diagnostic information.
 #'     Standard fields populated by the dispatcher:
@@ -289,6 +294,13 @@
 #' recorded in `result$backend_meta$tnrs_replacements` as a named
 #' character vector `(original = resolved)`. A one-shot `cli` warning
 #' lists the first few substitutions on the call itself.
+#'
+#' TNRS also returns structured match metadata. `pr_get_tree()` records
+#' it per name in the `mapping` tibble: `tnrs_number_matches`,
+#' `tnrs_is_synonym`, `tnrs_approximate_match`, and `tnrs_flags`. When a
+#' name resolves to more than one taxon (`tnrs_number_matches > 1`, a
+#' homonym), a one-shot `cli` warning names the affected species, since
+#' the resolved name is then only one of several candidates.
 #'
 #' @seealso [reconcile_tree()] / [reconcile_data()] for producing the
 #'   reconciled species list that feeds this function;
@@ -610,7 +622,8 @@ pr_get_tree <- function(
     query_name = resolved$query,
     in_tree = in_query,
     tree = result$tree,
-    backend_meta = backend_meta
+    backend_meta = backend_meta,
+    tnrs_audit = resolved$tnrs_audit
   )
 
   out <- list(
@@ -669,7 +682,8 @@ pr_get_tree <- function(
   query_name,
   in_tree,
   tree,
-  backend_meta = list()
+  backend_meta = list(),
+  tnrs_audit = NULL
 ) {
   input_name <- as.character(input_name)
   normalized_name <- as.character(normalized_name)
@@ -713,6 +727,32 @@ pr_get_tree <- function(
   match_type[normalized_match] <- "normalized"
   match_type[tnrs_match] <- "tnrs"
 
+  # TNRS match-quality columns. Present (as NA) even for backends or
+  # `tnrs` settings where TNRS did not run, so the mapping schema is
+  # stable across every call.
+  n_rows <- length(input_name)
+  has_audit <- is.data.frame(tnrs_audit) && nrow(tnrs_audit) == n_rows
+  tnrs_number_matches <- if (has_audit) {
+    as.integer(tnrs_audit$tnrs_number_matches)
+  } else {
+    rep(NA_integer_, n_rows)
+  }
+  tnrs_is_synonym <- if (has_audit) {
+    as.logical(tnrs_audit$tnrs_is_synonym)
+  } else {
+    rep(NA, n_rows)
+  }
+  tnrs_approximate_match <- if (has_audit) {
+    as.logical(tnrs_audit$tnrs_approximate_match)
+  } else {
+    rep(NA, n_rows)
+  }
+  tnrs_flags <- if (has_audit) {
+    as.character(tnrs_audit$tnrs_flags)
+  } else {
+    rep(NA_character_, n_rows)
+  }
+
   tibble::tibble(
     input_name = input_name,
     normalized_name = normalized_name,
@@ -720,7 +760,11 @@ pr_get_tree <- function(
     tree_name = tree_name,
     in_tree = in_tree,
     match_type = match_type,
-    placement_status = placement_status
+    placement_status = placement_status,
+    tnrs_number_matches = tnrs_number_matches,
+    tnrs_is_synonym = tnrs_is_synonym,
+    tnrs_approximate_match = tnrs_approximate_match,
+    tnrs_flags = tnrs_flags
   )
 }
 
@@ -878,6 +922,60 @@ pr_get_tree <- function(
 }
 
 
+# Internal: pull TNRS's structured match-quality columns
+# (number_matches, is_synonym, approximate_match, flags) out of a
+# tnrs_match_names() result and realign them to `normalised` via the
+# `row` index. rotl always returns these columns; the NULL guard means
+# a test mock or an upstream rotl change degrades to NA rather than
+# erroring. Returns a tibble with one row per element of `row`.
+.pr_tnrs_audit_table <- function(tnrs_res, row) {
+  n <- length(row)
+  realign <- function(name, na_value, coerce) {
+    v <- tnrs_res[[name]]
+    if (is.null(v)) {
+      return(rep(na_value, n))
+    }
+    if (is.list(v)) {
+      v <- vapply(v, function(x) paste(x, collapse = ","), character(1))
+    }
+    coerce(v[row])
+  }
+  tibble::tibble(
+    tnrs_number_matches = realign("number_matches", NA_integer_, as.integer),
+    tnrs_is_synonym = realign("is_synonym", NA, as.logical),
+    tnrs_approximate_match = realign("approximate_match", NA, as.logical),
+    tnrs_flags = realign("flags", NA_character_, as.character)
+  )
+}
+
+
+# Internal: emit a one-shot cli warning when TNRS reports more than one
+# taxonomic match for an input name (a homonym). The resolved name is
+# then only one of several candidate taxa, so the user should inspect
+# `result$mapping`. `input` and `number_matches` are index-aligned.
+.pr_warn_tnrs_homonyms <- function(input, number_matches) {
+  homonym <- !is.na(number_matches) & number_matches > 1L
+  if (!any(homonym)) {
+    return(invisible())
+  }
+  n_hom <- sum(homonym)
+  examples_n <- min(3L, n_hom)
+  examples <- paste(
+    sprintf(
+      "'%s' (%d matches)",
+      input[homonym][seq_len(examples_n)],
+      number_matches[homonym][seq_len(examples_n)]
+    ),
+    collapse = "; "
+  )
+  cli::cli_warn(c(
+    "TNRS found multiple taxonomic matches for {n_hom} input name{?s} (possible homonym{?s}).",
+    "i" = "The resolved name is only one candidate taxon; check {.code result$mapping$tnrs_number_matches} and {.code result$mapping$tnrs_flags}.",
+    ">" = "e.g. {examples}"
+  ))
+}
+
+
 .pr_resolve_query <- function(species, source, tnrs) {
   original <- unique(stats::na.omit(as.character(species)))
   normalised <- pr_normalize_names(original)
@@ -892,6 +990,7 @@ pr_get_tree <- function(
 
   resolved <- normalised
   tnrs_replacements <- NULL
+  tnrs_audit <- NULL
 
   if (do_tnrs && requireNamespace("rotl", quietly = TRUE)) {
     # `rotl::tnrs_match_names()` de-duplicates (and may reorder) its
@@ -918,6 +1017,12 @@ pr_get_tree <- function(
       # leaks into the query and the species silently fails to match a
       # tree tip.
       matched_name <- as.character(pr_normalize_names(matched_name))
+
+      # Capture TNRS's structured match-quality columns so pr_get_tree()
+      # can surface them per name in `result$mapping`. Realigned to
+      # `normalised` by the same `row` index used for `matched_name`.
+      tnrs_audit <- .pr_tnrs_audit_table(tnrs_res, row)
+
       replaced_idx <- !is.na(matched_name) &
         nzchar(matched_name) &
         matched_name != normalised
@@ -943,6 +1048,10 @@ pr_get_tree <- function(
           ">" = "e.g. {examples}"
         ))
       }
+
+      # Flag homonyms: TNRS reporting more than one match means the
+      # resolved name is only one of several candidate taxa.
+      .pr_warn_tnrs_homonyms(original, tnrs_audit$tnrs_number_matches)
     }
   } else if (do_tnrs && !requireNamespace("rotl", quietly = TRUE)) {
     if (!isTRUE(getOption("prepR4pcm.tnrs_warning_shown"))) {
@@ -960,7 +1069,8 @@ pr_get_tree <- function(
     normalised = normalised,
     resolved = resolved,
     query = resolved,
-    tnrs_replacements = tnrs_replacements
+    tnrs_replacements = tnrs_replacements,
+    tnrs_audit = tnrs_audit
   )
 }
 

--- a/man/pr_date_tree.Rd
+++ b/man/pr_date_tree.Rd
@@ -49,8 +49,9 @@ database (returned with no calibration applied).}
 \item{\code{mapping}}{A tibble with one row per input tip label,
 mirroring \code{\link[=pr_get_tree]{pr_get_tree()}}'s audit table: \code{input_name},
 \code{normalized_name}, \code{query_name}, \code{tree_name}, \code{in_tree},
-\code{match_type}, and \code{placement_status} (\code{NA} for DateLife
-dating).}
+\code{match_type}, \code{placement_status}, and the four \verb{tnrs_*}
+columns. \code{placement_status} and the \verb{tnrs_*} columns are \code{NA}
+for DateLife dating, which applies no TNRS step.}
 \item{\code{source}}{Always \code{"datelife"} (paired with \code{pr_get_tree()}'s
 dispatch).}
 \item{\code{backend_meta}}{Includes \code{dating_method}, \code{calibrations}

--- a/man/pr_get_tree.Rd
+++ b/man/pr_get_tree.Rd
@@ -232,17 +232,22 @@ input} that did not resolve. Disjoint from \code{matched};
 \code{length(matched) + length(unmatched) == length(unique(input))}
 always holds. Inspect these and consider running them back
 through \code{\link[=reconcile_suggest]{reconcile_suggest()}} / a manual override.}
-\item{\code{mapping}}{A tibble with one row per unique input species:
-\code{input_name}, \code{normalized_name}, \code{query_name}, \code{tree_name},
-\code{in_tree}, \code{match_type}, and \code{placement_status}. This is the
-audit trail for name handling: \code{input_name} is what the user
-supplied, \code{normalized_name} is the result of
+\item{\code{mapping}}{A tibble with one row per unique input species.
+Core columns: \code{input_name}, \code{normalized_name}, \code{query_name},
+\code{tree_name}, \code{in_tree}, \code{match_type}, and \code{placement_status}.
+This is the audit trail for name handling: \code{input_name} is what
+the user supplied, \code{normalized_name} is the result of
 \code{\link[=pr_normalize_names]{pr_normalize_names()}}, \code{query_name} is the backend query after
 optional TNRS, \code{tree_name} is the actual returned tip label, and
 \code{match_type} is one of \code{"exact"}, \code{"normalized"}, \code{"tnrs"}, or
 \code{"unmatched"}. For \code{source = "rtrees"}, \code{placement_status}
 carries the grafting status from \code{backend_meta$placement};
-otherwise it is \code{NA}.}
+otherwise it is \code{NA}. Four further columns record what \code{rotl}'s
+TNRS resolver reported for each name: \code{tnrs_number_matches},
+\code{tnrs_is_synonym}, \code{tnrs_approximate_match}, and \code{tnrs_flags}.
+These are \code{NA} for backends or \code{tnrs} settings where TNRS did
+not run. \code{tnrs_number_matches > 1} flags a homonym, meaning the
+resolved name is only one of several candidate taxa.}
 \item{\code{source}}{The backend that produced the tree.}
 \item{\code{backend_meta}}{A named list of diagnostic information.
 Standard fields populated by the dispatcher:
@@ -309,6 +314,13 @@ the \code{fishtree} backend under \code{tnrs = "auto"}), the replacement is
 recorded in \code{result$backend_meta$tnrs_replacements} as a named
 character vector \code{(original = resolved)}. A one-shot \code{cli} warning
 lists the first few substitutions on the call itself.
+
+TNRS also returns structured match metadata. \code{pr_get_tree()} records
+it per name in the \code{mapping} tibble: \code{tnrs_number_matches},
+\code{tnrs_is_synonym}, \code{tnrs_approximate_match}, and \code{tnrs_flags}. When a
+name resolves to more than one taxon (\code{tnrs_number_matches > 1}, a
+homonym), a one-shot \code{cli} warning names the affected species, since
+the resolved name is then only one of several candidates.
 }
 \examples{
 \donttest{

--- a/tests/testthat/test-pr_date_tree.R
+++ b/tests/testthat/test-pr_date_tree.R
@@ -158,7 +158,11 @@ test_that("pr_date_tree returns a per-tip mapping table", {
       "tree_name",
       "in_tree",
       "match_type",
-      "placement_status"
+      "placement_status",
+      "tnrs_number_matches",
+      "tnrs_is_synonym",
+      "tnrs_approximate_match",
+      "tnrs_flags"
     )
   )
   expect_equal(res$mapping$input_name, c("a", "b"))

--- a/tests/testthat/test-pr_get_tree.R
+++ b/tests/testthat/test-pr_get_tree.R
@@ -949,7 +949,11 @@ test_that("result mapping audits original, query, and tree names", {
       "tree_name",
       "in_tree",
       "match_type",
-      "placement_status"
+      "placement_status",
+      "tnrs_number_matches",
+      "tnrs_is_synonym",
+      "tnrs_approximate_match",
+      "tnrs_flags"
     )
   )
   expect_equal(
@@ -967,6 +971,9 @@ test_that("result mapping audits original, query, and tree names", {
   expect_equal(res$mapping$in_tree, c(TRUE, TRUE, FALSE))
   expect_equal(res$mapping$match_type, c("normalized", "exact", "unmatched"))
   expect_equal(res$mapping$placement_status, rep(NA_character_, 3L))
+  # tnrs = "never": the TNRS audit columns are present but all NA
+  expect_true(all(is.na(res$mapping$tnrs_number_matches)))
+  expect_true(all(is.na(res$mapping$tnrs_flags)))
 })
 
 

--- a/tests/testthat/test-pr_resolve_query-tnrs-audit.R
+++ b/tests/testthat/test-pr_resolve_query-tnrs-audit.R
@@ -1,0 +1,161 @@
+# Tests: TNRS match-metadata capture.
+#
+# .pr_resolve_query() pulls rotl::tnrs_match_names()'s structured
+# columns (number_matches, is_synonym, approximate_match, flags) into a
+# `tnrs_audit` table and warns when a name is a homonym
+# (number_matches > 1). .pr_build_tree_mapping() surfaces those columns
+# in `result$mapping`.
+
+# A tnrs_match_names() mock that returns the full audit-column set.
+# Each of `number_matches`, `is_synonym`, `approximate_match`, `flags`
+# is recycled to one row per unique input name; pass a vector aligned
+# to the de-duplicated input order to vary a column per name.
+fake_tnrs_audit <- function(unique_name = identity,
+                            number_matches = 1L,
+                            is_synonym = FALSE,
+                            approximate_match = FALSE,
+                            flags = "") {
+  function(names, ...) {
+    u <- unique(names)
+    recycle <- function(x) if (length(x) == 1L) rep(x, length(u)) else x
+    data.frame(
+      search_string     = tolower(u),
+      unique_name       = if (is.function(unique_name)) {
+        unique_name(u)
+      } else {
+        recycle(unique_name)
+      },
+      number_matches    = recycle(number_matches),
+      is_synonym        = recycle(is_synonym),
+      approximate_match = recycle(approximate_match),
+      flags             = recycle(flags),
+      stringsAsFactors  = FALSE
+    )
+  }
+}
+
+
+test_that(".pr_resolve_query captures TNRS audit columns", {
+  skip_if_not_installed("rotl")
+
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_audit(
+      number_matches    = c(1L, 1L),
+      is_synonym        = c(FALSE, TRUE),
+      approximate_match = c(FALSE, TRUE),
+      flags             = c("", "sibling_higher")
+    ),
+    .package = "rotl"
+  )
+
+  res <- .pr_resolve_query(
+    c("Salmo salar", "Esox lucius"),
+    source = "fishtree", tnrs = "always"
+  )
+
+  expect_s3_class(res$tnrs_audit, "data.frame")
+  expect_equal(nrow(res$tnrs_audit), 2L)
+  expect_named(
+    res$tnrs_audit,
+    c("tnrs_number_matches", "tnrs_is_synonym",
+      "tnrs_approximate_match", "tnrs_flags")
+  )
+  expect_equal(res$tnrs_audit$tnrs_number_matches, c(1L, 1L))
+  expect_equal(res$tnrs_audit$tnrs_is_synonym, c(FALSE, TRUE))
+  expect_equal(res$tnrs_audit$tnrs_approximate_match, c(FALSE, TRUE))
+  expect_equal(res$tnrs_audit$tnrs_flags, c("", "sibling_higher"))
+})
+
+
+test_that(".pr_resolve_query warns when TNRS reports a homonym", {
+  skip_if_not_installed("rotl")
+
+  # "Prunella" is a genuine homonym (a bird genus and a plant genus);
+  # TNRS reports number_matches = 2 for it, 1 for the unambiguous name.
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_audit(number_matches = c(2L, 1L)),
+    .package = "rotl"
+  )
+
+  expect_warning(
+    res <- .pr_resolve_query(
+      c("Prunella", "Salmo salar"),
+      source = "fishtree", tnrs = "always"
+    ),
+    "homonym"
+  )
+  expect_equal(res$tnrs_audit$tnrs_number_matches, c(2L, 1L))
+})
+
+
+test_that(".pr_resolve_query does not warn when every name has one match", {
+  skip_if_not_installed("rotl")
+
+  testthat::local_mocked_bindings(
+    tnrs_match_names = fake_tnrs_audit(number_matches = 1L),
+    .package = "rotl"
+  )
+
+  expect_no_warning(
+    .pr_resolve_query(
+      c("Salmo salar", "Esox lucius"),
+      source = "fishtree", tnrs = "always"
+    )
+  )
+})
+
+
+test_that(".pr_resolve_query returns NULL tnrs_audit when TNRS does not run", {
+  res <- .pr_resolve_query(
+    c("Salmo salar", "Esox lucius"),
+    source = "fishtree", tnrs = "never"
+  )
+  expect_null(res$tnrs_audit)
+})
+
+
+test_that(".pr_build_tree_mapping surfaces TNRS audit columns", {
+  audit <- tibble::tibble(
+    tnrs_number_matches    = c(1L, 2L),
+    tnrs_is_synonym        = c(FALSE, TRUE),
+    tnrs_approximate_match = c(FALSE, FALSE),
+    tnrs_flags             = c("", "sibling_higher")
+  )
+  tree <- ape::read.tree(text = "(Salmo_salar:1,Esox_lucius:1);")
+
+  m <- .pr_build_tree_mapping(
+    input_name      = c("Salmo salar", "Esox lucius"),
+    normalized_name = c("Salmo salar", "Esox lucius"),
+    query_name      = c("Salmo salar", "Esox lucius"),
+    in_tree         = c(TRUE, TRUE),
+    tree            = tree,
+    tnrs_audit      = audit
+  )
+
+  expect_true(all(
+    c("tnrs_number_matches", "tnrs_is_synonym",
+      "tnrs_approximate_match", "tnrs_flags") %in% names(m)
+  ))
+  expect_equal(m$tnrs_number_matches, c(1L, 2L))
+  expect_equal(m$tnrs_is_synonym, c(FALSE, TRUE))
+  expect_equal(m$tnrs_flags, c("", "sibling_higher"))
+})
+
+
+test_that(".pr_build_tree_mapping fills NA TNRS columns when audit is NULL", {
+  tree <- ape::read.tree(text = "(Salmo_salar:1,Esox_lucius:1);")
+
+  m <- .pr_build_tree_mapping(
+    input_name      = c("Salmo salar", "Esox lucius"),
+    normalized_name = c("Salmo salar", "Esox lucius"),
+    query_name      = c("Salmo salar", "Esox lucius"),
+    in_tree         = c(TRUE, TRUE),
+    tree            = tree,
+    tnrs_audit      = NULL
+  )
+
+  expect_true(all(is.na(m$tnrs_number_matches)))
+  expect_true(all(is.na(m$tnrs_flags)))
+  expect_type(m$tnrs_number_matches, "integer")
+  expect_type(m$tnrs_flags, "character")
+})


### PR DESCRIPTION
## Summary

Extends the Round 17 `pr_get_tree()` mapping audit table with the structured match metadata that `rotl`'s TNRS resolver already returns.

- **`result$mapping` gains four columns** from `rotl::tnrs_match_names()`: `tnrs_number_matches`, `tnrs_is_synonym`, `tnrs_approximate_match`, `tnrs_flags`. They are `NA` for backends or `tnrs` settings where TNRS did not run, so the mapping schema is stable across every call.
- **Homonym warning.** When TNRS reports more than one taxonomic match for a name (`tnrs_number_matches > 1`), `pr_get_tree()` emits a one-shot warning naming the affected species, since the resolved name is then only one of several candidate taxa.
- `.pr_resolve_query()` captures the audit columns realigned to the input; `.pr_build_tree_mapping()` gains a `tnrs_audit` argument. `pr_date_tree()`'s mapping gains the same four columns (all `NA`, as DateLife dating applies no TNRS step).

## Test plan

- [x] `devtools::test()` — 2684 pass. New `test-pr_resolve_query-tnrs-audit.R` (6 tests: column capture, homonym warning, no-warning, NULL-when-off, mapping append, NULL→NA). Extended the exact-column `expect_named` assertions in `test-pr_get_tree.R` and `test-pr_date_tree.R`.
- [x] `devtools::document()` — `pr_get_tree.Rd` / `pr_date_tree.Rd` regenerated.

Note: two failures on `main` (`test-claim-suggests-conditional.R`, `test-claim-suggests-remotes-consistency.R`, both about `piggyback` in `DESCRIPTION` Suggests) are pre-existing and unrelated — this PR makes no `DESCRIPTION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)