### PR TITLE
test: allowlist piggyback as a transitive megatrees/rtrees Suggests

### DIFF
--- a/tests/testthat/test-claim-suggests-conditional.R
+++ b/tests/testthat/test-claim-suggests-conditional.R
@@ -4,7 +4,7 @@
 # in R/ or vignettes/ is guarded so that the package functions /
 # vignettes degrade gracefully when the Suggests dependency is absent.
 #
-# Three buckets per Suggests entry, in priority order:
+# Four buckets per Suggests entry, in priority order:
 #
 #   R-guarded:   referenced under R/ AND at least one
 #                requireNamespace(<pkg>, quietly = TRUE) check exists
@@ -20,8 +20,19 @@
 #                are tooling Suggests that don't need user-facing
 #                guards because they're only invoked by the package
 #                infrastructure.
+#
+#   Transitive:  a Suggests entry declared only so the dependency
+#                resolver installs it for another Suggests' own
+#                dependency chain -- not called by prepR4pcm itself.
+#                Held in `transitive_suggests` below.
 
 allowlisted <- c("knitr", "rmarkdown", "testthat", "pkgdown", "spelling")
+
+# Transitive-only Suggests: declared in `Suggests:` not because
+# prepR4pcm calls them, but so the dependency resolver installs them
+# for a GitHub-only Suggests' own dependency chain. `piggyback` backs
+# `megatrees`, a transitive dependency of the `rtrees` backend (PR #91).
+transitive_suggests <- c("piggyback")
 
 
 .find_root_with_dirs <- function(dirs) {
@@ -75,7 +86,7 @@ test_that("every Suggests package is conditionally guarded", {
   vig_blob <- read_all(vig_files)
 
   for (pkg in pkgs) {
-    if (pkg %in% allowlisted) next
+    if (pkg %in% allowlisted || pkg %in% transitive_suggests) next
 
     in_r        <- grepl(paste0("\\b", pkg, "::"), r_blob, perl = TRUE) ||
                    grepl(paste0("requireNamespace\\(\\s*[\"']", pkg, "[\"']"),

--- a/tests/testthat/test-claim-suggests-remotes-consistency.R
+++ b/tests/testthat/test-claim-suggests-remotes-consistency.R
@@ -19,7 +19,8 @@
 .cran_allowlist <- c(
   "ape", "cli", "rlang", "tibble",
   "caper", "digest", "dplyr", "fishtree", "knitr", "MCMCglmm", "phytools",
-  "pkgdown", "readr", "rmarkdown", "rotl", "spelling", "stringr", "taxadb",
+  "piggyback", "pkgdown", "readr", "rmarkdown", "rotl", "spelling", "stringr",
+  "taxadb",
   "testthat",
   # standard packages bundled with R
   "stats", "tools", "utils", "graphics", "grDevices", "methods"


### PR DESCRIPTION
## Summary

`devtools::test()` on `main` reported two failures, both about `piggyback` in `DESCRIPTION` Suggests:

- `test-claim-suggests-conditional.R` — `piggyback` is in Suggests but not referenced in `R/` or `vignettes/`.
- `test-claim-suggests-remotes-consistency.R` — `piggyback` is on neither the CRAN allowlist nor in `Remotes:`.

**Root cause:** `piggyback` was added to Suggests in PR #91 (so the dependency resolver installs it for `megatrees`, a transitive dependency of the `rtrees` backend), but the matching allowlist updates in the two "claim" tests were missed.

**Fix:**
- Added `piggyback` to `.cran_allowlist` in `test-claim-suggests-remotes-consistency.R` — it is a CRAN package, the documented escape hatch.
- Added a `transitive_suggests` allowlist to `test-claim-suggests-conditional.R`, mirroring the existing `.transitive_remotes_allowlist` pattern, for Suggests entries declared only for dependency resolution.

No `DESCRIPTION` or package-code change.

## Test plan

- [x] `devtools::test(filter = "claim-suggests")` — both files pass (15 assertions, 0 fail). The full suite is now `FAIL 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)