### PR TITLE
docs(posterior-tree-pipeline): repair broken pipeline code

### DIFF
--- a/docs/articles/posterior-tree-pipeline.html
+++ b/docs/articles/posterior-tree-pipeline.html
@@ -25,7 +25,7 @@
 
     <a class="navbar-brand me-2" href="../index.html">prepR4pcm</a>
 
-    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Released version">0.4.0.9000</small>
+    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">0.4.0.9000</small>
 
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -118,53 +118,63 @@ axes of uncertainty.</li>
 <span><span class="co"># pak::pak("itchyshin/pigauto")</span></span></code></pre></div>
 </div>
 <div class="section level2">
-<h2 id="step-1-reconcile-names">Step 1 — Reconcile names<a class="anchor" aria-label="anchor" href="#step-1-reconcile-names"></a>
+<h2 id="step-1-retrieve-a-posterior-of-trees">Step 1 — Retrieve a posterior of trees<a class="anchor" aria-label="anchor" href="#step-1-retrieve-a-posterior-of-trees"></a>
 </h2>
 <p>Start with whatever names appear in your dataset. They never quite
-match the tree’s tip labels.</p>
+match a tree’s tip labels — formatting drifts, synonyms creep in.
+<code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> copes: it normalises every name (underscores,
+whitespace, authority strings) and, for the <code>fishtree</code>
+backend, resolves synonyms through Open Tree of Life’s Taxonomic Name
+Resolution Service before querying the backend.</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span><span class="co"># Your data and your tree — typically loaded from disk</span></span>
+<code class="sourceCode R"><span><span class="co"># Your trait data — typically loaded from disk. Names need not be</span></span>
+<span><span class="co"># tidy: `Esox_lucius` carries an underscore, which pr_get_tree()</span></span>
+<span><span class="co"># normalises away.</span></span>
 <span><span class="va">my_data</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/data.frame.html" class="external-link">data.frame</a></span><span class="op">(</span></span>
-<span>  species   <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"Salmo salar"</span>, <span class="st">"Esox lucius"</span>, <span class="st">"Esox_lucius"</span>,</span>
-<span>                <span class="st">"Oncorhynchus mykiss"</span><span class="op">)</span>,</span>
-<span>  body_size <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="fl">98</span>, <span class="fl">130</span>, <span class="cn">NA</span>, <span class="fl">50</span><span class="op">)</span>   <span class="co"># NA is OK; pigauto will impute</span></span>
-<span><span class="op">)</span></span>
-<span></span>
-<span><span class="co"># Reconcile names against a published taxonomic authority. Catches</span></span>
-<span><span class="co"># typos, formatting drift, and synonymy.</span></span>
-<span><span class="va">rec</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/reconcile_data.html">reconcile_data</a></span><span class="op">(</span><span class="va">my_data</span>,</span>
-<span>                      x_species <span class="op">=</span> <span class="st">"species"</span>,</span>
-<span>                      authority <span class="op">=</span> <span class="st">"col"</span><span class="op">)</span>  <span class="co"># Catalogue of Life</span></span>
-<span><span class="va">rec</span>   <span class="co"># one-line summary of matched / unmatched / counts</span></span></code></pre></div>
-</div>
-<div class="section level2">
-<h2 id="step-2-get-a-posterior-of-trees">Step 2 — Get a posterior of trees<a class="anchor" aria-label="anchor" href="#step-2-get-a-posterior-of-trees"></a>
-</h2>
+<span>  species   <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"Salmo salar"</span>, <span class="st">"Esox_lucius"</span>, <span class="st">"Oncorhynchus mykiss"</span><span class="op">)</span>,</span>
+<span>  body_size <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="fl">98</span>, <span class="cn">NA</span>, <span class="fl">50</span><span class="op">)</span>        <span class="co"># NA is fine; pigauto will impute it</span></span>
+<span><span class="op">)</span></span></code></pre></div>
 <p>Every backend that <em>can</em> return multiple trees does so via
 <code>n_tree &gt; 1</code>. Here we ask <code>fishtree</code> for 50
 stochastic resolutions (Chang, Rabosky, Alfaro 2019, <em>Syst.
 Biol.</em>).</p>
 <div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span><span class="va">trees</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">rec</span>,</span>
-<span>                     source <span class="op">=</span> <span class="st">"fishtree"</span>,</span>
-<span>                     n_tree <span class="op">=</span> <span class="fl">50</span><span class="op">)</span></span>
+<code class="sourceCode R"><span><span class="va">trees</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">my_data</span>,</span>
+<span>                     species_col <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>                     source      <span class="op">=</span> <span class="st">"fishtree"</span>,</span>
+<span>                     n_tree      <span class="op">=</span> <span class="fl">50</span><span class="op">)</span></span>
 <span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/class.html" class="external-link">class</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span>             <span class="co"># "multiPhylo"</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span>            <span class="co"># 50</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">matched</span><span class="op">)</span>         <span class="co"># how many species placed</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/utils/head.html" class="external-link">head</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">unmatched</span><span class="op">)</span>         <span class="co"># species absent from fishtree</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/class.html" class="external-link">class</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span>      <span class="co"># "multiPhylo"</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">)</span>     <span class="co"># 50</span></span>
+<span><span class="va">trees</span><span class="op">$</span><span class="va">matched</span>          <span class="co"># the 3 species, in their original input form</span></span>
+<span><span class="va">trees</span><span class="op">$</span><span class="va">unmatched</span>        <span class="co"># character(0) — every species was placed</span></span>
 <span></span>
-<span><span class="co"># Per-tree provenance: one entry per tree</span></span>
-<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">)</span>  <span class="co"># 50</span></span>
-<span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span></span></code></pre></div>
+<span><span class="co"># Per-tree provenance: one entry per returned tree</span></span>
+<span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">)</span>   <span class="co"># 50</span></span>
+<span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span></span>
+<span><span class="co">#&gt; $source_index</span></span>
+<span><span class="co">#&gt; [1] 1</span></span>
+<span><span class="co">#&gt;</span></span>
+<span><span class="co">#&gt; $citation</span></span>
+<span><span class="co">#&gt; [1] "Rabosky et al. (2018) Nature 559:392 (doi:10.1038/s41586-018-0273-1)"</span></span>
+<span><span class="co">#&gt;</span></span>
+<span><span class="co">#&gt; $calibration_method</span></span>
+<span><span class="co">#&gt; [1] "stochastic polytomy resolution"</span></span>
+<span><span class="co">#&gt;</span></span>
+<span><span class="co">#&gt; $n_tips</span></span>
+<span><span class="co">#&gt; [1] 3</span></span></code></pre></div>
+<p><code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> records what happened to every name in
+<code>trees$mapping</code> (one row per input species), so a name that
+quietly fell out of the tree cannot go unnoticed.</p>
 <p>For the universal-but-slower option, use
 <code>source = "datelife"</code> — the chronogram-database backend that
 returns one calibrated tree per source (Hedges, Bininda-Emonds, Upham,
 etc.).</p>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span><span class="va">trees</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">rec</span>,</span>
-<span>                     source <span class="op">=</span> <span class="st">"datelife"</span>,</span>
-<span>                     n_tree <span class="op">=</span> <span class="fl">50</span><span class="op">)</span></span>
+<code class="sourceCode R"><span><span class="va">trees</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/pr_get_tree.html">pr_get_tree</a></span><span class="op">(</span><span class="va">my_data</span>,</span>
+<span>                     species_col <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>                     source      <span class="op">=</span> <span class="st">"datelife"</span>,</span>
+<span>                     n_tree      <span class="op">=</span> <span class="fl">50</span><span class="op">)</span></span>
 <span><span class="co"># trees$tree is multiPhylo; per-source citations are in</span></span>
 <span><span class="co"># trees$backend_meta$tree_provenance[[i]]$citation</span></span></code></pre></div>
 <p>If you already have a topology and want to <em>date</em> it (rather
@@ -189,10 +199,41 @@ al. 2019), then pass that <code>multiPhylo</code> to
 topology × source cross-product.</p>
 </div>
 <div class="section level2">
+<h2 id="step-2-reconcile-the-data-to-the-posterior">Step 2 — Reconcile the data to the posterior<a class="anchor" aria-label="anchor" href="#step-2-reconcile-the-data-to-the-posterior"></a>
+</h2>
+<p><code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> resolves names well enough to
+<em>retrieve</em> a tree, but the modelling step needs a data frame
+whose rows line up one-to-one with the tree’s tips.
+<code><a href="../reference/reconcile_tree.html">reconcile_tree()</a></code> matches your data against the retrieved
+topology, and <code><a href="../reference/reconcile_apply.html">reconcile_apply()</a></code> returns the aligned
+data–tree pair. The 50 posterior trees share one tip set, so reconciling
+against the first tree aligns the data to all of them.</p>
+<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span><span class="va">rec</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/reconcile_tree.html">reconcile_tree</a></span><span class="op">(</span><span class="va">my_data</span>, <span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span>,</span>
+<span>                      x_species <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>                      authority <span class="op">=</span> <span class="cn">NULL</span><span class="op">)</span>   <span class="co"># tree tips are plain binomials</span></span>
+<span><span class="va">rec</span>        <span class="co"># match summary: 1 exact, 2 normalized, 0 unresolved</span></span>
+<span></span>
+<span><span class="va">aligned</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/reconcile_apply.html">reconcile_apply</a></span><span class="op">(</span><span class="va">rec</span>,</span>
+<span>                           data            <span class="op">=</span> <span class="va">my_data</span>,</span>
+<span>                           tree            <span class="op">=</span> <span class="va">trees</span><span class="op">$</span><span class="va">tree</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span>,</span>
+<span>                           species_col     <span class="op">=</span> <span class="st">"species"</span>,</span>
+<span>                           drop_unresolved <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span>
+<span></span>
+<span><span class="va">aligned</span><span class="op">$</span><span class="va">data</span>    <span class="co"># one row per tree tip — the model-ready frame</span></span>
+<span><span class="co">#&gt;               species body_size</span></span>
+<span><span class="co">#&gt; 1         Salmo salar        98</span></span>
+<span><span class="co">#&gt; 2         Esox_lucius        NA</span></span>
+<span><span class="co">#&gt; 3 Oncorhynchus mykiss        50</span></span></code></pre></div>
+<p><code>aligned$data</code> carries one row per species in the tree,
+with <code>Esox_lucius</code> keeping the <code>NA</code> that pigauto
+will impute; <code>aligned$tree</code> is the matching pruned tree.</p>
+</div>
+<div class="section level2">
 <h2 id="step-3-format-citations-do-this-before-you-submit">Step 3 — Format citations (do this <em>before</em> you submit)<a class="anchor" aria-label="anchor" href="#step-3-format-citations-do-this-before-you-submit"></a>
 </h2>
 <p>Reviewers ask. Save yourself the round-trip.</p>
-<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="co"># Plain text for an email or a methods paragraph</span></span>
 <span><span class="fu"><a href="../reference/pr_cite_tree.html">pr_cite_tree</a></span><span class="op">(</span><span class="va">trees</span><span class="op">)</span></span>
 <span></span>
@@ -212,11 +253,11 @@ topology × source cross-product.</p>
 complete-data imputations <em>per tree</em>. The output knows which
 imputation came from which tree, and pigauto’s pooling step later uses
 that index.</p>
-<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
+<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="kw"><a href="https://rdrr.io/r/base/library.html" class="external-link">library</a></span><span class="op">(</span><span class="va">pigauto</span><span class="op">)</span></span>
 <span></span>
 <span><span class="co"># 5 imputations per tree × 50 trees = 250 complete datasets</span></span>
-<span><span class="va">mi</span> <span class="op">&lt;-</span> <span class="fu">multi_impute_trees</span><span class="op">(</span><span class="va">rec</span><span class="op">$</span><span class="va">aligned</span>,</span>
+<span><span class="va">mi</span> <span class="op">&lt;-</span> <span class="fu">multi_impute_trees</span><span class="op">(</span><span class="va">aligned</span><span class="op">$</span><span class="va">data</span>,</span>
 <span>                         trees      <span class="op">=</span> <span class="va">trees</span><span class="op">$</span><span class="va">tree</span>,</span>
 <span>                         m_per_tree <span class="op">=</span> <span class="fl">5</span><span class="op">)</span></span>
 <span></span>
@@ -389,7 +430,20 @@ speciation rate for marine fishes.</em> Nature 559: 392–395. <a href="https://
 
 
 
-
-
-  </body>
+  <script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pkgdown emits ```mermaid``` as <pre class="mermaid"><code>...</code></pre>
+  // (or, for some pandoc paths, <pre><code class="language-mermaid">).
+  // Mermaid.js wants <div class="mermaid"> with raw text content, so we
+  // unwrap the <code> and replace the <pre> with a <div>.
+  document.querySelectorAll('pre.mermaid > code, pre > code.language-mermaid').forEach((codeEl) => {
+    const pre = codeEl.parentElement;
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = codeEl.textContent;
+    pre.replaceWith(div);
+  });
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral', securityLevel: 'loose' });
+</script>
+</body>
 </html>

--- a/vignettes/posterior-tree-pipeline.Rmd
+++ b/vignettes/posterior-tree-pipeline.Rmd
@@ -57,56 +57,69 @@ library(prepR4pcm)
 # pak::pak("itchyshin/pigauto")
 ```
 
-## Step 1 — Reconcile names
+## Step 1 — Retrieve a posterior of trees
 
 Start with whatever names appear in your dataset. They never quite
-match the tree's tip labels.
+match a tree's tip labels — formatting drifts, synonyms creep in.
+`pr_get_tree()` copes: it normalises every name (underscores,
+whitespace, authority strings) and, for the `fishtree` backend,
+resolves synonyms through Open Tree of Life's Taxonomic Name
+Resolution Service before querying the backend.
 
-```{r reconcile, eval = FALSE}
-# Your data and your tree — typically loaded from disk
+```{r data}
+# Your trait data — typically loaded from disk. Names need not be
+# tidy: `Esox_lucius` carries an underscore, which pr_get_tree()
+# normalises away.
 my_data <- data.frame(
-  species   = c("Salmo salar", "Esox lucius", "Esox_lucius",
-                "Oncorhynchus mykiss"),
-  body_size = c(98, 130, NA, 50)   # NA is OK; pigauto will impute
+  species   = c("Salmo salar", "Esox_lucius", "Oncorhynchus mykiss"),
+  body_size = c(98, NA, 50)        # NA is fine; pigauto will impute it
 )
-
-# Reconcile names against a published taxonomic authority. Catches
-# typos, formatting drift, and synonymy.
-rec <- reconcile_data(my_data,
-                      x_species = "species",
-                      authority = "col")  # Catalogue of Life
-rec   # one-line summary of matched / unmatched / counts
 ```
-
-## Step 2 — Get a posterior of trees
 
 Every backend that *can* return multiple trees does so via
 `n_tree > 1`. Here we ask `fishtree` for 50 stochastic resolutions
 (Chang, Rabosky, Alfaro 2019, *Syst. Biol.*).
 
 ```{r retrieve, eval = FALSE}
-trees <- pr_get_tree(rec,
-                     source = "fishtree",
-                     n_tree = 50)
+trees <- pr_get_tree(my_data,
+                     species_col = "species",
+                     source      = "fishtree",
+                     n_tree      = 50)
 
-class(trees$tree)             # "multiPhylo"
-length(trees$tree)            # 50
-length(trees$matched)         # how many species placed
-head(trees$unmatched)         # species absent from fishtree
+class(trees$tree)      # "multiPhylo"
+length(trees$tree)     # 50
+trees$matched          # the 3 species, in their original input form
+trees$unmatched        # character(0) — every species was placed
 
-# Per-tree provenance: one entry per tree
-length(trees$backend_meta$tree_provenance)  # 50
+# Per-tree provenance: one entry per returned tree
+length(trees$backend_meta$tree_provenance)   # 50
 trees$backend_meta$tree_provenance[[1]]
+#> $source_index
+#> [1] 1
+#>
+#> $citation
+#> [1] "Rabosky et al. (2018) Nature 559:392 (doi:10.1038/s41586-018-0273-1)"
+#>
+#> $calibration_method
+#> [1] "stochastic polytomy resolution"
+#>
+#> $n_tips
+#> [1] 3
 ```
+
+`pr_get_tree()` records what happened to every name in
+`trees$mapping` (one row per input species), so a name that quietly
+fell out of the tree cannot go unnoticed.
 
 For the universal-but-slower option, use `source = "datelife"` —
 the chronogram-database backend that returns one calibrated tree per
 source (Hedges, Bininda-Emonds, Upham, etc.).
 
 ```{r datelife, eval = FALSE}
-trees <- pr_get_tree(rec,
-                     source = "datelife",
-                     n_tree = 50)
+trees <- pr_get_tree(my_data,
+                     species_col = "species",
+                     source      = "datelife",
+                     n_tree      = 50)
 # trees$tree is multiPhylo; per-source citations are in
 # trees$backend_meta$tree_provenance[[i]]$citation
 ```
@@ -133,6 +146,38 @@ To get 50 different *topologies*, fetch them separately first (e.g.
 100 mammal topologies sampled from VertLife / Upham et al. 2019),
 then pass that `multiPhylo` to `pr_date_tree()` to date each one.
 That gives you the topology × source cross-product.
+
+## Step 2 — Reconcile the data to the posterior
+
+`pr_get_tree()` resolves names well enough to *retrieve* a tree, but
+the modelling step needs a data frame whose rows line up one-to-one
+with the tree's tips. `reconcile_tree()` matches your data against
+the retrieved topology, and `reconcile_apply()` returns the aligned
+data–tree pair. The 50 posterior trees share one tip set, so
+reconciling against the first tree aligns the data to all of them.
+
+```{r reconcile, eval = FALSE}
+rec <- reconcile_tree(my_data, trees$tree[[1]],
+                      x_species = "species",
+                      authority = NULL)   # tree tips are plain binomials
+rec        # match summary: 1 exact, 2 normalized, 0 unresolved
+
+aligned <- reconcile_apply(rec,
+                           data            = my_data,
+                           tree            = trees$tree[[1]],
+                           species_col     = "species",
+                           drop_unresolved = TRUE)
+
+aligned$data    # one row per tree tip — the model-ready frame
+#>               species body_size
+#> 1         Salmo salar        98
+#> 2         Esox_lucius        NA
+#> 3 Oncorhynchus mykiss        50
+```
+
+`aligned$data` carries one row per species in the tree, with
+`Esox_lucius` keeping the `NA` that pigauto will impute;
+`aligned$tree` is the matching pruned tree.
 
 ## Step 3 — Format citations (do this *before* you submit)
 
@@ -161,7 +206,7 @@ later uses that index.
 library(pigauto)
 
 # 5 imputations per tree × 50 trees = 250 complete datasets
-mi <- multi_impute_trees(rec$aligned,
+mi <- multi_impute_trees(aligned$data,
                          trees      = trees$tree,
                          m_per_tree = 5)
 


### PR DESCRIPTION
## Summary

`posterior-tree-pipeline.Rmd` is `eval = FALSE`, which hid that its code did not run.

**Root cause:** `reconcile_data()` reconciles two datasets and requires `y`; the vignette called it with only `x`, so `rec` was never created. `pr_get_tree(rec, …)` and `rec$aligned` then both chained off a non-existent object.

**Fix:**
- **Step 1** retrieves the posterior directly: `pr_get_tree(my_data, species_col = "species", source = "fishtree", n_tree = 50)`. `pr_get_tree()` normalises names and runs TNRS itself, so there is no separate "reconcile names" step before retrieval.
- **Step 2** aligns the data to the posterior with `reconcile_tree()` + `reconcile_apply()`; `aligned$data` is the model-ready frame, replacing the non-existent `rec$aligned` in the pigauto step.
- Dropped the literal `Esox lucius` / `Esox_lucius` duplicate from the example data — it made `reconcile_apply()` silently drop the row carrying the real trait value (130) and keep the `NA` row.

## Test plan

- [x] Whole pipeline verified live: `pr_get_tree(source = "fishtree", n_tree = 50)` → `multiPhylo[50]`, all 3 species matched, 0 unmatched; `reconcile_tree()` + `reconcile_apply()` → 3-row `aligned$data`, 0 dropped. Inline annotations and the `#>` output blocks are copied from that run.
- [x] `pkgdown::build_article("posterior-tree-pipeline")` renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)