### PR TITLE
fix(posterior-tree-pipeline vignette): drop bare doi from output block

### DIFF
--- a/docs/articles/posterior-tree-pipeline.html
+++ b/docs/articles/posterior-tree-pipeline.html
@@ -149,20 +149,10 @@ Biol.</em>).</p>
 <span><span class="va">trees</span><span class="op">$</span><span class="va">matched</span>          <span class="co"># the 3 species, in their original input form</span></span>
 <span><span class="va">trees</span><span class="op">$</span><span class="va">unmatched</span>        <span class="co"># character(0) — every species was placed</span></span>
 <span></span>
-<span><span class="co"># Per-tree provenance: one entry per returned tree</span></span>
+<span><span class="co"># Per-tree provenance: one list entry per returned tree, each</span></span>
+<span><span class="co"># recording source_index, citation, calibration_method, and n_tips.</span></span>
 <span><span class="fu"><a href="https://rdrr.io/r/base/length.html" class="external-link">length</a></span><span class="op">(</span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">)</span>   <span class="co"># 50</span></span>
-<span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span></span>
-<span><span class="co">#&gt; $source_index</span></span>
-<span><span class="co">#&gt; [1] 1</span></span>
-<span><span class="co">#&gt;</span></span>
-<span><span class="co">#&gt; $citation</span></span>
-<span><span class="co">#&gt; [1] "Rabosky et al. (2018) Nature 559:392 (doi:10.1038/s41586-018-0273-1)"</span></span>
-<span><span class="co">#&gt;</span></span>
-<span><span class="co">#&gt; $calibration_method</span></span>
-<span><span class="co">#&gt; [1] "stochastic polytomy resolution"</span></span>
-<span><span class="co">#&gt;</span></span>
-<span><span class="co">#&gt; $n_tips</span></span>
-<span><span class="co">#&gt; [1] 3</span></span></code></pre></div>
+<span><span class="va">trees</span><span class="op">$</span><span class="va">backend_meta</span><span class="op">$</span><span class="va">tree_provenance</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span>      <span class="co"># the provenance of tree 1</span></span></code></pre></div>
 <p><code><a href="../reference/pr_get_tree.html">pr_get_tree()</a></code> records what happened to every name in
 <code>trees$mapping</code> (one row per input species), so a name that
 quietly fell out of the tree cannot go unnoticed.</p>

--- a/vignettes/posterior-tree-pipeline.Rmd
+++ b/vignettes/posterior-tree-pipeline.Rmd
@@ -91,20 +91,10 @@ length(trees$tree)     # 50
 trees$matched          # the 3 species, in their original input form
 trees$unmatched        # character(0) — every species was placed
 
-# Per-tree provenance: one entry per returned tree
+# Per-tree provenance: one list entry per returned tree, each
+# recording source_index, citation, calibration_method, and n_tips.
 length(trees$backend_meta$tree_provenance)   # 50
-trees$backend_meta$tree_provenance[[1]]
-#> $source_index
-#> [1] 1
-#>
-#> $citation
-#> [1] "Rabosky et al. (2018) Nature 559:392 (doi:10.1038/s41586-018-0273-1)"
-#>
-#> $calibration_method
-#> [1] "stochastic polytomy resolution"
-#>
-#> $n_tips
-#> [1] 3
+trees$backend_meta$tree_provenance[[1]]      # the provenance of tree 1
 ```
 
 `pr_get_tree()` records what happened to every name in


### PR DESCRIPTION
## Summary

Follow-up to #101. The `#>` output block added there reproduced `trees$backend_meta$tree_provenance[[1]]`, whose `citation` field is a plain-text string containing a bare `doi:10.1038/s41586-018-0273-1`. The `test-claim-no-bare-doi.R` guard scans every vignette `.Rmd` line for a bare `doi:10.` and flagged it — `devtools::test()` failed on `main` (`FAIL 1`).

Replaced the multi-line `#>` block with a one-line comment naming the provenance fields (`source_index`, `citation`, `calibration_method`, `n_tips`).

## Test plan

- [x] `devtools::test()` — **`FAIL 0 | PASS 2685`** (was `FAIL 1`).
- [x] `pkgdown::build_article("posterior-tree-pipeline")` renders cleanly.

Note: `test-claim-no-bare-doi.R` scans inside fenced code blocks, where a bare `doi:` is harmless — pandoc does not auto-link inside code blocks, so there is no dead-link risk. That is a latent false-positive (`pr_cite_tree()` output legitimately contains `doi:` strings); narrowing the test is left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)