### PR TITLE
chore: narrow no-bare-doi test, tidy bird-workflow chunk

### DIFF
--- a/docs/articles/bird-workflow.html
+++ b/docs/articles/bird-workflow.html
@@ -130,7 +130,7 @@ variants, taxonomic synonyms — are exactly what prepR4pcm resolves.</p>
 <span><span class="co">#&gt;   Source x: avonet_subset</span></span>
 <span><span class="co">#&gt;   Source y: phylo (657 tips)</span></span>
 <span><span class="co">#&gt;   Authority: none</span></span>
-<span><span class="co">#&gt;   Timestamp: 2026-05-15 11:47:45</span></span>
+<span><span class="co">#&gt;   Timestamp: 2026-05-22 11:51:30</span></span>
 <span><span class="co">#&gt; <span style="color: #00BBBB;">ℹ</span> Match coverage: [█████████████████████░░░░░░░░░] 71% (657/919)</span></span>
 <span><span class="co">#&gt; </span></span>
 <span><span class="co">#&gt; ── <span style="font-weight: bold;">Match summary</span> ──</span></span>
@@ -344,7 +344,7 @@ analyse.</strong></p>
 <span><span class="co">#&gt;   Source x: nesttrait_subset</span></span>
 <span><span class="co">#&gt;   Source y: avonet_subset</span></span>
 <span><span class="co">#&gt;   Authority: none</span></span>
-<span><span class="co">#&gt;   Timestamp: 2026-05-15 11:48:03</span></span>
+<span><span class="co">#&gt;   Timestamp: 2026-05-22 11:51:48</span></span>
 <span><span class="co">#&gt; <span style="color: #00BBBB;">ℹ</span> Match coverage: [██████████████████████████████] 100% (916/916)</span></span>
 <span><span class="co">#&gt; </span></span>
 <span><span class="co">#&gt; ── <span style="font-weight: bold;">Match summary</span> ──</span></span>
@@ -580,7 +580,6 @@ tree using genus-level placement:</p>
 <span>  <span class="va">result</span>,</span>
 <span>  <span class="va">tree_jetz</span>,</span>
 <span>  where <span class="op">=</span> <span class="st">"genus"</span>,                <span class="co"># sister to a random congener</span></span>
-<span></span>
 <span>  branch_length <span class="op">=</span> <span class="st">"congener_median"</span>,  <span class="co"># median terminal branch of congeners</span></span>
 <span>  seed <span class="op">=</span> <span class="fl">42</span>,                      <span class="co"># for reproducibility</span></span>
 <span>  quiet <span class="op">=</span> <span class="cn">TRUE</span></span>
@@ -790,7 +789,20 @@ modern phylogenetics and evolutionary analyses in R.
 
 
 
-
-
-  </body>
+  <script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pkgdown emits ```mermaid``` as <pre class="mermaid"><code>...</code></pre>
+  // (or, for some pandoc paths, <pre><code class="language-mermaid">).
+  // Mermaid.js wants <div class="mermaid"> with raw text content, so we
+  // unwrap the <code> and replace the <pre> with a <div>.
+  document.querySelectorAll('pre.mermaid > code, pre > code.language-mermaid').forEach((codeEl) => {
+    const pre = codeEl.parentElement;
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = codeEl.textContent;
+    pre.replaceWith(div);
+  });
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral', securityLevel: 'loose' });
+</script>
+</body>
 </html>

--- a/tests/testthat/test-claim-no-bare-doi.R
+++ b/tests/testthat/test-claim-no-bare-doi.R
@@ -7,8 +7,10 @@
 # `[doi:10.xxx](https://doi.org/10.xxx)`.
 #
 # This test scans every .Rmd / README.md for bare doi: outside of a
-# completed markdown link. If any survive, the deployed site has dead
-# links.
+# completed markdown link and outside fenced code blocks. If any
+# survive in prose, the deployed site has dead links. (A bare doi:
+# inside a ``` fence is literal text -- pandoc does not auto-link
+# inside code -- so those carry no dead-link risk.)
 
 test_that("no bare doi: URIs in user-facing files (issue: PR #28 regression)", {
   skip_on_cran()
@@ -28,8 +30,17 @@ test_that("no bare doi: URIs in user-facing files (issue: PR #28 regression)", {
   bad_lines <- character()
   for (f in files) {
     src <- readLines(f, warn = FALSE)
+    in_code_fence <- FALSE
     for (i in seq_along(src)) {
       line <- src[i]
+      # Toggle in/out of fenced code blocks. A bare `doi:` inside a
+      # ``` fence is literal text (pandoc does not auto-link inside
+      # code), so it is not a dead-link risk and is skipped.
+      if (grepl("^\\s*```", line)) {
+        in_code_fence <- !in_code_fence
+        next
+      }
+      if (in_code_fence) next
       # Look for a `doi:10.xxx` substring whose preceding char is
       # NOT `]`+`(` (markdown link) and NOT inside `[...]` brackets.
       # Cheap heuristic: every `doi:10.` must have a preceding `[`

--- a/vignettes/bird-workflow.Rmd
+++ b/vignettes/bird-workflow.Rmd
@@ -400,7 +400,6 @@ aug <- reconcile_augment(
   result,
   tree_jetz,
   where = "genus",                # sister to a random congener
-
   branch_length = "congener_median",  # median terminal branch of congeners
   seed = 42,                      # for reproducibility
   quiet = TRUE


### PR DESCRIPTION
## Summary

Three small cleanups (all flagged in the post-merge review):

- **`test-claim-no-bare-doi.R`** now skips lines inside fenced code blocks. A bare `doi:` inside a ``` fence is literal text — pandoc does not auto-link inside code — so it carries no dead-link risk. Without this, the guard false-positives on any vignette that displays `pr_cite_tree()` or `tree_provenance` output (those strings legitimately contain `doi:`). The test still catches bare `doi:` in prose, which is its real job.
- **`bird-workflow.Rmd`** — removed a stray blank line inside the `reconcile_augment()` call in the `augment` chunk.
- Deleted a stale untracked `man/figures/posterior-tree-example.png` (a 2-tip figure from a pre-#96 render script, unused).

## Test plan

- [x] `devtools::test(filter = "claim-no-bare-doi")` — `FAIL 0 | PASS 2`.
- [x] `pkgdown::build_article("bird-workflow")` renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)