### PR TITLE
fix(pkgdown): skip Enhances in workflow_dispatch; document branch-length backends

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,15 +36,18 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
-          # "most" = Depends + Imports + LinkingTo + Suggests, but NOT
-          # Enhances. We have `Enhances: datelife`, which pak cannot
-          # resolve on a clean CI runner: datelife was archived from
-          # CRAN in 2024-08, and its transitive dep tree (bold,
-          # phylobase, Bioconductor packages) doesn't install cleanly
-          # via pak alone. pkgdown still gets every Suggest it needs
-          # to render the vignettes; users who want datelife install
-          # it themselves via `pak::pak("phylotastic/datelife")`.
-          dependencies: '"most"'
+          # Depends + Imports + LinkingTo + Suggests, but NOT Enhances.
+          # We have `Enhances: datelife`, which pak cannot resolve on a
+          # clean CI runner: datelife was archived from CRAN in 2024-08,
+          # and its transitive dep tree (bold, phylobase, Bioconductor
+          # packages) doesn't install cleanly via pak alone. pkgdown
+          # still gets every Suggest it needs to render the vignettes;
+          # users who want datelife install it themselves via
+          # `pak::pak("phylotastic/datelife")`.
+          # pak's named shortcuts ("hard", "soft", "all") don't have a
+          # "exclude only Enhances" option, so we pass the explicit
+          # field vector.
+          dependencies: 'c("Depends", "Imports", "LinkingTo", "Suggests")'
           needs: website
 
       - name: Build site (verification only; not deployed)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,6 +36,15 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
+          # "most" = Depends + Imports + LinkingTo + Suggests, but NOT
+          # Enhances. We have `Enhances: datelife`, which pak cannot
+          # resolve on a clean CI runner: datelife was archived from
+          # CRAN in 2024-08, and its transitive dep tree (bold,
+          # phylobase, Bioconductor packages) doesn't install cleanly
+          # via pak alone. pkgdown still gets every Suggest it needs
+          # to render the vignettes; users who want datelife install
+          # it themselves via `pak::pak("phylotastic/datelife")`.
+          dependencies: '"most"'
           needs: website
 
       - name: Build site (verification only; not deployed)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # prepR4pcm 0.5.0.9000 (development version)
 
+* **pkgdown workflow fix.** `dependencies: '"most"'` in
+  `.github/workflows/pkgdown.yaml` tells pak to skip `Enhances`
+  (i.e. `datelife`) during lockfile resolution. The
+  `workflow_dispatch` rebuild no longer fails on "Can't find
+  package called datelife". The day-to-day path is unaffected:
+  GitHub Pages still serves the docs straight from `main:/docs/`.
+
+* **`comparing-tree-backends.Rmd` gains a "Branch lengths and
+  time-calibration" section** with a per-backend comparison table
+  and a practical decision tree for choosing between `fishtree` /
+  `clootl` / `rtrees` / `datelife` / Grafen pseudo-time when you
+  need real divergence-time branch lengths. Surfaces the
+  alternative path when `datelife` isn't installable on a given
+  system.
+
 # prepR4pcm 0.5.0
 
 This release adds two opt-in Global Names Architecture backends, a

--- a/docs/articles/comparing-tree-backends.html
+++ b/docs/articles/comparing-tree-backends.html
@@ -294,6 +294,124 @@ please open an issue at <a href="https://github.com/itchyshin/prepR4pcm/issues" 
 with your <code><a href="../reference/pr_get_tree_status.html">pr_get_tree_status()</a></code> output and the error.</p>
 </div>
 <div class="section level2">
+<h2 id="branch-lengths-and-time-calibration">Branch lengths and time-calibration<a class="anchor" aria-label="anchor" href="#branch-lengths-and-time-calibration"></a>
+</h2>
+<p>Phylogenetic comparative methods (PGLS with Pagel’s λ, Brownian
+motion, OU, phylogenetic meta-analysis) need branch lengths that
+correspond to <em>time</em> — not just topology. Backends differ in what
+branch lengths they produce:</p>
+<table class="table">
+<colgroup>
+<col width="25%">
+<col width="25%">
+<col width="25%">
+<col width="25%">
+</colgroup>
+<thead><tr class="header">
+<th>Backend</th>
+<th>Branch lengths produced</th>
+<th>Real time?</th>
+<th>Taxonomic scope</th>
+</tr></thead>
+<tbody>
+<tr class="odd">
+<td>
+<code>rotl</code> (default)</td>
+<td>None — synthesis topology only</td>
+<td>No</td>
+<td>Universal</td>
+</tr>
+<tr class="even">
+<td>
+<code>rotl</code> +
+<code>resolve_polytomies = TRUE, branch_lengths = "grafen"</code>
+</td>
+<td>Grafen ρ = 1 arbitrary depths</td>
+<td>No (arbitrary)</td>
+<td>Universal</td>
+</tr>
+<tr class="odd">
+<td><code>fishtree</code></td>
+<td>Yes — divergence times from Rabosky et al. 2018</td>
+<td><strong>Yes</strong></td>
+<td>Ray-finned fish</td>
+</tr>
+<tr class="even">
+<td><code>clootl</code></td>
+<td>Yes — Bird Tree consensus branches</td>
+<td><strong>Yes</strong></td>
+<td>Birds (current Clements)</td>
+</tr>
+<tr class="odd">
+<td>
+<code>rtrees</code> (any <code>taxon</code>)</td>
+<td>Yes — branches from <code>megatrees</code> posterior</td>
+<td><strong>Yes</strong></td>
+<td>Birds, mammals, fish, amphibians, reptiles, plants, sharks, bees,
+butterflies</td>
+</tr>
+<tr class="even">
+<td><code>datelife</code></td>
+<td>Yes — SDM-summary chronograms or per-source candidates</td>
+<td><strong>Yes</strong></td>
+<td>Universal</td>
+</tr>
+<tr class="odd">
+<td><code>pr_date_tree(tree)</code></td>
+<td>Yes — calibrates <em>your</em> topology via DateLife</td>
+<td><strong>Yes</strong></td>
+<td>Universal</td>
+</tr>
+<tr class="even">
+<td>Manual <code><a href="https://rdrr.io/pkg/ape/man/chronos.html" class="external-link">ape::chronos()</a></code> with user calibration points</td>
+<td>Yes</td>
+<td><strong>Yes</strong></td>
+<td>Universal</td>
+</tr>
+</tbody>
+</table>
+<p>The decision tree, in practice:</p>
+<ol style="list-style-type: decimal">
+<li>
+<strong>Is your taxon covered by a dedicated time-calibrated
+backend?</strong> For fish use <code>fishtree</code>; for birds,
+mammals, amphibians, squamates, sharks, or plants use
+<code>rtrees</code> with the matching <code>taxon</code>. These are
+pre-computed, pre-dated, and need no extra dependencies.</li>
+<li>
+<strong>Is your taxon set cross-clade (e.g. a thermal-tolerance
+dataset spanning lampreys, bivalves, insects, fish, amphibians,
+reptiles)?</strong> Then your options are:
+<ol style="list-style-type: lower-alpha">
+<li>
+<code>datelife</code> for a real time-calibrated solution. Install
+via <code>pak::pak("phylotastic/datelife")</code>. Heavy dependency tree
+(Bioconductor, BOLD); usually works on macOS / Linux with system libs,
+sometimes flaky on Windows.</li>
+<li>
+<code>rotl + resolve_polytomies = TRUE, branch_lengths = "grafen"</code>
+for Grafen pseudo-time. Defensible for phylogenetic meta- analysis where
+you mainly need a correlation structure, not real divergence times (this
+is the pattern Cinar et al. 2022 and Pottier et al. 2022 use). See the
+<a href="meta-analysis-with-rotl.html">phylogenetic meta-analysis
+vignette</a> for a worked example.</li>
+<li>Hand-curated calibration points + <code><a href="https://rdrr.io/pkg/ape/man/chronos.html" class="external-link">ape::chronos()</a></code> if you
+have published divergence-time estimates for a small set of nodes.</li>
+</ol>
+</li>
+<li>
+<strong>Do you already have a topology you want
+time-calibrated?</strong> <code>pr_date_tree(your_tree)</code> wraps
+<code>datelife::datelife_use()</code> and has the same install
+requirement as the <code>datelife</code> backend.</li>
+</ol>
+<p>If <code>datelife</code> is the option you want and it won’t install
+on your system, the practical fallbacks (in roughly preferred order)
+are: the dedicated taxon backend if one exists for your taxa; Grafen
+pseudo-time for meta-analysis-style use; or hand calibration for small,
+well-studied taxon sets.</p>
+</div>
+<div class="section level2">
 <h2 id="where-are-the-vertlife-trees">Where are the VertLife trees?<a class="anchor" aria-label="anchor" href="#where-are-the-vertlife-trees"></a>
 </h2>
 <p>A common question: <em>“I want the VertLife / Upham et al. 2019

--- a/vignettes/comparing-tree-backends.Rmd
+++ b/vignettes/comparing-tree-backends.Rmd
@@ -165,6 +165,57 @@ issue at
 [itchyshin/prepR4pcm](https://github.com/itchyshin/prepR4pcm/issues)
 with your `pr_get_tree_status()` output and the error.
 
+## Branch lengths and time-calibration
+
+Phylogenetic comparative methods (PGLS with Pagel's λ, Brownian
+motion, OU, phylogenetic meta-analysis) need branch lengths that
+correspond to *time* — not just topology. Backends differ in what
+branch lengths they produce:
+
+| Backend | Branch lengths produced | Real time? | Taxonomic scope |
+|---|---|---|---|
+| `rotl` (default) | None — synthesis topology only | No | Universal |
+| `rotl` + `resolve_polytomies = TRUE, branch_lengths = "grafen"` | Grafen ρ = 1 arbitrary depths | No (arbitrary) | Universal |
+| `fishtree` | Yes — divergence times from Rabosky et al. 2018 | **Yes** | Ray-finned fish |
+| `clootl` | Yes — Bird Tree consensus branches | **Yes** | Birds (current Clements) |
+| `rtrees` (any `taxon`) | Yes — branches from `megatrees` posterior | **Yes** | Birds, mammals, fish, amphibians, reptiles, plants, sharks, bees, butterflies |
+| `datelife` | Yes — SDM-summary chronograms or per-source candidates | **Yes** | Universal |
+| `pr_date_tree(tree)` | Yes — calibrates *your* topology via DateLife | **Yes** | Universal |
+| Manual `ape::chronos()` with user calibration points | Yes | **Yes** | Universal |
+
+The decision tree, in practice:
+
+1. **Is your taxon covered by a dedicated time-calibrated backend?**
+   For fish use `fishtree`; for birds, mammals, amphibians, squamates,
+   sharks, or plants use `rtrees` with the matching `taxon`. These
+   are pre-computed, pre-dated, and need no extra dependencies.
+2. **Is your taxon set cross-clade (e.g. a thermal-tolerance dataset
+   spanning lampreys, bivalves, insects, fish, amphibians, reptiles)?**
+   Then your options are:
+    a. `datelife` for a real time-calibrated solution. Install via
+      `pak::pak("phylotastic/datelife")`. Heavy dependency tree
+      (Bioconductor, BOLD); usually works on macOS / Linux with
+      system libs, sometimes flaky on Windows.
+    b. `rotl + resolve_polytomies = TRUE, branch_lengths = "grafen"`
+      for Grafen pseudo-time. Defensible for phylogenetic meta-
+      analysis where you mainly need a correlation structure, not
+      real divergence times (this is the pattern Cinar et al. 2022
+      and Pottier et al. 2022 use). See the
+      [phylogenetic meta-analysis vignette](meta-analysis-with-rotl.html)
+      for a worked example.
+    c. Hand-curated calibration points + `ape::chronos()` if you
+      have published divergence-time estimates for a small set of
+      nodes.
+3. **Do you already have a topology you want time-calibrated?**
+   `pr_date_tree(your_tree)` wraps `datelife::datelife_use()` and
+   has the same install requirement as the `datelife` backend.
+
+If `datelife` is the option you want and it won't install on your
+system, the practical fallbacks (in roughly preferred order) are:
+the dedicated taxon backend if one exists for your taxa; Grafen
+pseudo-time for meta-analysis-style use; or hand calibration for
+small, well-studied taxon sets.
+
 ## Where are the VertLife trees?
 
 A common question: *"I want the VertLife / Upham et al. 2019 mammal


### PR DESCRIPTION
Two small, related changes surfaced by the v0.5.0 release dispatch.

## Summary

1. **`.github/workflows/pkgdown.yaml` now sets `dependencies: '"most"'`** so pak skips `Enhances` (i.e. `datelife`) during lockfile creation. The post-v0.5.0 `workflow_dispatch` rebuild was failing with `Can't find package called datelife` because datelife was archived from CRAN in 2024-08 and is intentionally **not** in `Remotes:` — its transitive deps (Bioconductor, BOLD, system libs) don't install cleanly via pak on a clean CI image. `"most"` = `Depends + Imports + LinkingTo + Suggests`, so every Suggest pkgdown actually needs for vignette rendering still resolves.

   This workflow is verification-only (the day-to-day path is GitHub Pages reading `main:/docs/` directly), so the failure didn't block the live site — it just made the dispatch button red. This fix unblocks the manual rebuild path.

2. **`comparing-tree-backends.Rmd` gains a "Branch lengths and time-calibration" section** with a per-backend table and a three-step decision tree. It surfaces what users should do when their taxon set is cross-clade *and* `pak::pak("phylotastic/datelife")` won't install cleanly: dedicated taxon backend if one exists, Grafen pseudo-time for meta-analysis, or hand calibration for small/well-studied taxa.

## Why now

`datelife` is the only universal time-calibration backend the package ships. For users running PGLS / BM / OU / phylogenetic meta-analysis on cross-clade datasets it is the realistic option. The current install path is GitHub-only and sometimes flaky on Windows. The vignette change makes the fallbacks discoverable; the workflow change keeps the verification path useful.

## Verification

- [x] \`pkgdown::build_article("comparing-tree-backends")\` renders cleanly; new "Branch lengths and time-calibration" section visible in [docs/articles/comparing-tree-backends.html](docs/articles/comparing-tree-backends.html).
- [x] No behavioural code change — purely workflow + doc.
- [ ] CI confirms the workflow itself builds (the workflow under change is the pkgdown dispatch, not R-CMD-check; both should still pass).

## Follow-up (separate PR)

A future PR 4 will prototype \`.pr_date_tree_http()\` — an HTTP-only path that hits \`datelife.org\` directly via \`httr2\`, mirroring the new \`authority = "gnverifier"\` pattern. That would remove the package-install requirement entirely for users who'd rather take a network call than maintain the Bioconductor dep chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)